### PR TITLE
Deeper model structures for external parameters

### DIFF
--- a/astromodels/core/model.py
+++ b/astromodels/core/model.py
@@ -773,11 +773,14 @@ class Model(Node):
 
         return representation
 
-    def to_dict_with_types(self):
+    def to_dict_with_types(self,root=None):
 
         # Get the serialization dictionary
 
-        data = self.to_dict()
+        if root is None:
+            root=self
+
+        data = root.to_dict()
 
         # Add the types to the sources
 
@@ -785,7 +788,7 @@ class Model(Node):
 
             try:
 
-                element = self._get_child(key)
+                element = root._get_child(key)
 
             except KeyError:  # pragma: no cover
 
@@ -812,7 +815,10 @@ class Model(Node):
 
                 else: # pragma: no cover
 
-                    raise ModelInternalError("Found an unknown class at the top level")
+                    data.pop(key)
+                    data['%s (%s)' % (key, 'Node')] = self.to_dict_with_types(root=element)
+
+                #    raise ModelInternalError("Found an unknown class at the top level")
 
         return data
 

--- a/astromodels/tests/test_model.py
+++ b/astromodels/tests/test_model.py
@@ -394,7 +394,7 @@ def test_external_parameters_structured():
 
     # Link as equal (default)
     m._add_child(node)
-    m._add_child(fake_parameter)
+    node._add_child(fake_parameter)
     #m.add_external_parameter(fake_parameter)
 
     assert len(m.free_parameters) - 1 == n_free_before_external
@@ -406,6 +406,8 @@ def test_external_parameters_structured():
     # Now test that we can access it
 
     m['test_node.external_parameter']
+
+    cloned=clone_model(m)
 
 
 def test_input_output_basic():

--- a/astromodels/tests/test_model.py
+++ b/astromodels/tests/test_model.py
@@ -380,6 +380,33 @@ def test_external_parameters():
 
         m.add_external_parameter(fake_parameter)
 
+def test_external_parameters_structured():
+
+    mg = ModelGetter()
+
+    m = mg.model
+
+    n_free_before_external = len(m.free_parameters)
+
+    # Create parameter
+    node=Node("test_node")
+    fake_parameter = Parameter("external_parameter",1.0, min_value=-1.0, max_value=1.0, free=True)
+
+    # Link as equal (default)
+    m._add_child(node)
+    m._add_child(fake_parameter)
+    #m.add_external_parameter(fake_parameter)
+
+    assert len(m.free_parameters) - 1 == n_free_before_external
+
+    # Try to display it just to make sure it works
+
+    m.display()
+
+    # Now test that we can access it
+
+    m['test_node.external_parameter']
+
 
 def test_input_output_basic():
 


### PR DESCRIPTION
To avoid using too long parameter names, they can be instead organized in trees.

In particular, this can be used to structure the nuisance parameters. currently they are obliged to obey, just a contain name substring. this might even happen by accident:

```python
 assert dataset.name in parameter_name
```
This kind of parameter organization can be used to separate scopes of parameters in a more broad sense.