### PR TITLE
Stop overwriting point source position bounds when parsing model

### DIFF
--- a/astromodels/core/model_parser.py
+++ b/astromodels/core/model_parser.py
@@ -437,12 +437,15 @@ class SourceParser(object):
 
             ra = par_parser.get_variable()
 
-            ra.bounds = (0, 360)
+            if ra.bounds == (None, None):
+              ra.bounds = (0, 360)
 
             par_parser = ParameterParser('dec', sky_direction_definition['dec'])
 
             dec = par_parser.get_variable()
-            dec.bounds = (-90, 90)
+            
+            if dec.bounds == (None, None):
+              dec.bounds = (-90, 90)
 
             coordinates['ra'] = ra
             coordinates['dec'] = dec
@@ -452,12 +455,16 @@ class SourceParser(object):
             par_parser = ParameterParser('l', sky_direction_definition['l'])
 
             l = par_parser.get_variable()
-            l.bounds = (0, 360)
+            
+            if l.bounds == (None, None):
+              l.bounds = (0, 360)
 
             par_parser = ParameterParser('b', sky_direction_definition['b'])
 
             b = par_parser.get_variable()
-            b.bounds = (-90, 90)
+            
+            if b.bounds == (None, None):
+              b.bounds = (-90, 90)
 
             coordinates['l'] = l
             coordinates['b'] = b

--- a/astromodels/core/sky_direction.py
+++ b/astromodels/core/sky_direction.py
@@ -98,8 +98,8 @@ class SkyDirection(Node):
 
             parameter = number_or_parameter
 
-            assert parameter.min_value == minimum, "%s must have a minimum of %s" % (what, minimum)
-            assert parameter.max_value == maximum, "%s must have a maximum of %s" % (what, maximum)
+            assert parameter.min_value >= minimum, "%s must have a minimum greater than or equal to %s" % (what, minimum)
+            assert parameter.max_value <= maximum, "%s must have a maximum less than or equal to %s" % (what, maximum)
 
         else:
 


### PR DESCRIPTION
So I was having issues when fitting a point source with free position. I tracked it down to the fact that bounds on the point source position are 'lost' when loading a model from a yml file (I'm loading my input models from yml before starting the fit). 

The same thing happens when cloning the model, for example to compute the TS of each source.

Turns out that in `model_parser.py` and `sky_direction.py`, the bounds were forced to be 0 t0 360 for the right ascension and -90 to 90 for the declination, overwriting user-set bounds.

This is my attempt to fix it. Tests pass on my laptop. Was there a deeper reason for over-writing source position bounds? This did not seem to happen for extended sources, btw. 