### PR TITLE
use parameter path rather than name as dictionary key

### DIFF
--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -247,6 +247,8 @@ class ExtendedSource(Source, Node):
     def free_parameters(self):
         """
         Returns a dictionary of free parameters for this source
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """
@@ -271,7 +273,9 @@ class ExtendedSource(Source, Node):
     @property
     def parameters(self):
         """
-        Returns a dictionary of all parameters for this source
+        Returns a dictionary of all parameters for this source.
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -258,13 +258,13 @@ class ExtendedSource(Source, Node):
 
                 if par.free:
 
-                    free_parameters[par.name] = par
+                    free_parameters[par.path] = par
 
         for par in self.spatial_shape.parameters.values():
 
             if par.free:
 
-                free_parameters[par.name] = par
+                free_parameters[par.path] = par
 
         return free_parameters
 
@@ -281,11 +281,11 @@ class ExtendedSource(Source, Node):
 
             for par in component.shape.parameters.values():
 
-                all_parameters[par.name] = par
+                all_parameters[par.path] = par
 
         for par in self.spatial_shape.parameters.values():
 
-            all_parameters[par.name] = par
+            all_parameters[par.path] = par
 
         return all_parameters
 

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -93,7 +93,9 @@ class ParticleSource(Source, Node):
     @property
     def free_parameters(self):
         """
-        Returns a dictionary of free parameters for this source
+        Returns a dictionary of free parameters for this source.
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """
@@ -112,7 +114,9 @@ class ParticleSource(Source, Node):
     @property
     def parameters(self):
         """
-        Returns a dictionary of all parameters for this source
+        Returns a dictionary of all parameters for this source.
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -89,3 +89,41 @@ class ParticleSource(Source, Node):
             repr_dict[key]['spectrum'][component_name] = component.to_dict(minimal=True)
 
         return dict_to_list(repr_dict, rich_output)
+
+    @property
+    def free_parameters(self):
+        """
+        Returns a dictionary of free parameters for this source
+
+        :return:
+        """
+        free_parameters = collections.OrderedDict()
+
+        for component in self._components.values():
+
+            for par in component.shape.parameters.values():
+
+                if par.free:
+
+                    free_parameters[par.path] = par
+
+        return free_parameters
+
+    @property
+    def parameters(self):
+        """
+        Returns a dictionary of all parameters for this source
+
+        :return:
+        """
+        all_parameters = collections.OrderedDict()
+
+        for component in self._components.values():
+
+            for par in component.shape.parameters.values():
+
+                all_parameters[par.path] = par
+
+        return all_parameters
+
+

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -249,15 +249,36 @@ class PointSource(Source, Node):
 
                 if par.free:
 
-                    free_parameters[par.name] = par
+                    free_parameters[par.path] = par
 
         for par in self.position.parameters.values():
 
             if par.free:
 
-                free_parameters[par.name] = par
+                free_parameters[par.path] = par
 
         return free_parameters
+
+    @property
+    def parameters(self):
+        """
+        Returns a dictionary of all parameters for this source
+
+        :return:
+        """
+        all_parameters = collections.OrderedDict()
+
+        for component in self._components.values():
+
+            for par in component.shape.parameters.values():
+
+                all_parameters[par.path] = par
+
+        for par in self.position.parameters.values():
+
+            all_parameters[par.path] = par
+
+        return all_parameters
 
     def _repr__base(self, rich_output=False):
         """

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -237,7 +237,9 @@ class PointSource(Source, Node):
     @property
     def free_parameters(self):
         """
-        Returns a dictionary of free parameters for this source
+        Returns a dictionary of free parameters for this source.
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """
@@ -262,7 +264,9 @@ class PointSource(Source, Node):
     @property
     def parameters(self):
         """
-        Returns a dictionary of all parameters for this source
+        Returns a dictionary of all parameters for this source.
+        We use the parameter path as the key because it's 
+        guaranteed to be unique, unlike the parameter name.
 
         :return:
         """


### PR DESCRIPTION
See discussion https://github.com/threeML/astromodels/pull/99 and https://github.com/threeML/astromodels/issues/98

I changed the parameters() and free_parameters() functions of point_source.py and extended_source.py to use the parameter path, rather than its name, as a key.

(I also added parameters() properties to the point source and particle source classes).

I ran some tests to make sure everything works locally... It doesn't seem to affect the tests and I can ~not~ _now_ fit the offending gaussian galactic diffuse emission source.