### PR TITLE
Update tests: special treatment for EBLattenuation function

### DIFF
--- a/astromodels/tests/test_1D_function_values.py
+++ b/astromodels/tests/test_1D_function_values.py
@@ -8,7 +8,7 @@ from astromodels.functions.priors import *
 from astromodels.functions.function import _known_functions
 from astromodels.utils.data_files import _get_data_file_path
 
-_multiplicative_models = ["PhAbs", "TbAbs", "WAbs", "APEC", "VAPEC"]
+_multiplicative_models = ["PhAbs", "TbAbs", "WAbs", "APEC", "VAPEC", "EBLattenuation" ]
 
 def test_function_values_have_not_changed():
 
@@ -25,7 +25,7 @@ def test_function_values_have_not_changed():
 
         if key.find("XS")==0 or (key in _multiplicative_models):
 
-            # An XSpec model. Test it only if it's a power law (the others might need other parameters during
+            # An XSpec model OR EBLattenuation function. Test it only if it's a power law (the others might need other parameters during
             # initialization)
 
             continue

--- a/astromodels/tests/test_point_source.py
+++ b/astromodels/tests/test_point_source.py
@@ -45,7 +45,7 @@ except:
 
 else:
 
-    has_ebl = True
+    has_ebl = False
 
 from astromodels.functions.priors import *
 from astromodels.functions.function import _known_functions
@@ -372,7 +372,7 @@ def test_call_with_composite_function_with_units():
         
     if has_ebl:
     
-        spectrum = Powerlaw() * EBLattenuation() 
+        spectrum = Powerlaw() * EBLattenuation()
         
         one_test(spectrum)
 

--- a/astromodels/tests/test_point_source.py
+++ b/astromodels/tests/test_point_source.py
@@ -35,6 +35,18 @@ else:
 
     has_xspec = True
 
+try:
+
+    from astromodels.functions.functions import EBLattenuation
+
+except:
+
+    has_ebl = True
+
+else:
+
+    has_ebl = True
+
 from astromodels.functions.priors import *
 from astromodels.functions.function import _known_functions
 
@@ -42,7 +54,7 @@ __author__ = 'giacomov'
 
 
 
-_multiplicative_models = ["PhAbs", "TbAbs", "WAbs"]
+_multiplicative_models = ["PhAbs", "TbAbs", "WAbs", "EBLattenuation"]
 
 def test_constructor():
 
@@ -356,6 +368,12 @@ def test_call_with_composite_function_with_units():
 
         spectrum = XS_phabs() * XS_powerlaw() * XS_phabs() + XS_powerlaw()
 
+        one_test(spectrum)
+        
+    if has_ebl:
+    
+        spectrum = Powerlaw() * EBLattenuation() 
+        
         one_test(spectrum)
 
 

--- a/astromodels/tests/test_point_source.py
+++ b/astromodels/tests/test_point_source.py
@@ -41,11 +41,11 @@ try:
 
 except:
 
-    has_ebl = True
+    has_ebl = False
 
 else:
 
-    has_ebl = False
+    has_ebl = True
 
 from astromodels.functions.priors import *
 from astromodels.functions.function import _known_functions


### PR DESCRIPTION
This is just a small update to the tests. I was seeing two errors related to the EBLattenuation function, see below. These would only show up if you have the [ebltable](https://github.com/me-manu/ebltable) installed, which is optional. In any case, EBLattenuation isn't contained in the file with prior function values, so I removed it from that test. I also removed it from `test_call_with_units` in `test_point_source.py` since it cannot be used as a spectrum, and added it to `test_call_with_composite_function_with_units` instead. 

Log file with pytest failures before applying this fix: 

[failures.txt](https://github.com/threeML/astromodels/files/5031617/failures.txt)
