### PR TITLE
set default minimum for cutoff parameter; fix comments

### DIFF
--- a/astromodels/functions/functions.py
+++ b/astromodels/functions/functions.py
@@ -274,6 +274,7 @@ class Cutoff_powerlaw(Function1D):
             desc : Cutoff energy
             initial value : 10.0
             transformation : log10
+            min: 1.0
 
     """
 
@@ -406,7 +407,7 @@ class Super_cutoff_powerlaw(Function1D):
 
         xc :
 
-            desc : Photon index
+            desc : Cutoff energy
             initial value : 10.0
             min : 1.0
 


### PR DESCRIPTION
Add a default minimum for the cutoff energy in the cutoff_powerlaw function to avoid this warning:

```
$ python -c "import astromodels"
/Users/ich/hawc_software/miniconda3/envs/clean_hal/lib/python2.7/site-packages/astromodels/core/parameter.py:555: UserWarning: We have set the min_value of xc to 1e-99 because there was a postive transform
  warnings.warn('We have set the min_value of %s to 1e-99 because there was a postive transform' % self.path)
```

when loading astromodels.

Btw, I notice that `Cutoff_powerlaw.xc` has a log10 transform, but `Super_cutoff_powerlaw.xc` and `Exponential_cutoff.xc` do not. Is that intentional?
