### PR TITLE
remove pytables to see if tests pass

### DIFF
--- a/conda-dist/recipe/meta.yaml
+++ b/conda-dist/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     #- scipy
 #    - numdifftools
     #- hdf5
-   # - pytables
+    - pytables
     - pandas>=0.23
     - dill
     #- cfitsio

--- a/conda-dist/recipe/meta.yaml
+++ b/conda-dist/recipe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     #- scipy
 #    - numdifftools
     #- hdf5
-    - pytables
+   # - pytables
     - pandas>=0.23
     - dill
     #- cfitsio

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     numba
     h5py
     pandas
-    pytables
+
     
 tests_require =
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     numba
     h5py
     pandas
-
+    tables
     
 tests_require =
     pytest


### PR DESCRIPTION
I have removed PyTables as it seems to not be used and is causing issues with pip installs. @ndilalla can you double check that we aren't using it anywhere?