### PR TITLE
Convenience function: has_free_parameters for astromodels functions

### DIFF
--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -560,6 +560,17 @@ class Function(Node):
 
         return free_parameters
 
+    @property
+    def has_free_parameters(self):
+        """
+        Returns True or False depending on if any parameters are free
+        """
+
+        for p in self.parameters.values():
+            if p.free:
+                return True
+        return False
+
     @staticmethod
     def _generate_uuid():
         """


### PR DESCRIPTION
Trivial update: This pull request adds a `has_free_parameters` property to the astromodels functions class, so we can easily check if e.g. a source's spectrum or spatial shape has free parameters. 