### PR TITLE
Ensure xspec models known

### DIFF
--- a/astromodels/tests/test_load_xspec_models.py
+++ b/astromodels/tests/test_load_xspec_models.py
@@ -37,7 +37,7 @@ def test_xspec_load():
 def test_xspec_saving():
 
 
-    s = XS_phabs() * XS_powerlaw() + XS_bbody()
+    s =  XS_powerlaw() + XS_bbody()
 
     ps = PointSource("test", 0, 0, spectral_shape=s)
 

--- a/astromodels/tests/test_load_xspec_models.py
+++ b/astromodels/tests/test_load_xspec_models.py
@@ -2,7 +2,8 @@ from __future__ import print_function
 from __future__ import division
 import pytest
 import astropy.units as u
-
+from astromodels import clone_model, PointSource, Model, load_model
+from pathlib import Path
 try:
 
     from astromodels.xspec import *
@@ -30,3 +31,28 @@ def test_xspec_load():
     print(s(1.0))
     s.set_units(u.keV, 1 / (u.keV * u.cm**2 * u.s))
     print(s(1.0 * u.keV)) 
+
+
+@skip_if_xspec_is_not_available
+def test_xspec_saving():
+
+
+    s = XS_phabs() * XS_powerlaw() + XS_bbody()
+
+    ps = PointSource("test", 0, 0, spectral_shape=s)
+
+    model = Model(ps)
+
+
+    cloned_model = clone_model(model)
+
+    filename = "_test_xspec_model.yml"
+    
+    model.save(filename)
+
+    reloaded_model = load_model(filename)
+
+
+    p = Path(filename)
+
+    p.unlink()


### PR DESCRIPTION
adds a small test to make sure that xspec models can be reloaded. 