### PR TITLE
Fix for Issue #172

### DIFF
--- a/astromodels/functions/template_model.py
+++ b/astromodels/functions/template_model.py
@@ -709,7 +709,7 @@ class TemplateModel(with_metaclass(FunctionMeta, Function1D)):
                 # In more than 2d we can only use linear interpolation
 
                 this_interpolator = GridInterpolate(
-                    tuple([np.array(x) for x in list(self._parameters_grids.values())]),
+                    tuple([np.array(x,dtype='<f8') for x in list(self._parameters_grids.values())]),
                     this_data,
                 )
 


### PR DESCRIPTION
By specifying the dtype for the grid array in the interpolator the numba typing error is resolved.