### PR TITLE
Fix internal delta calculation in case of no bounds

### DIFF
--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -1060,7 +1060,7 @@ class Parameter(ParameterBase):
 
                 # Make sure we are within the margins
 
-                if low_bound_ext > self.min_value:
+                if (self.min_value is None) or (low_bound_ext > self.min_value):
 
                     # Ok, let's use that for the delta
                     low_bound_int = self._transformation.forward(low_bound_ext)
@@ -1075,7 +1075,7 @@ class Parameter(ParameterBase):
 
                     hi_bound_ext = self.value + self._delta
 
-                    if hi_bound_ext < self.max_value:
+                    if (self.max_value is None) or hi_bound_ext < self.max_value:
 
                         # Ok, let's use it
                         hi_bound_int = self._transformation.forward(hi_bound_ext)


### PR DESCRIPTION
The internal_delta calculation would fail in case there was a transform but no boundaries had been set on the parameter. 