### PR TITLE
Fix installation in Python 3.12

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -341,9 +341,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
From [Python 12 release notes](https://docs.python.org/3/whatsnew/3.12.html)
> [configparser](https://docs.python.org/3/library/configparser.html#module-configparser) no longer has a SafeConfigParser class. Use the shorter [ConfigParser](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser) name instead.
>[configparser.ConfigParser](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser) no longer has a readfp method. Use [read_file()](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file) instead.

I changed those names, and now it works. These were marked as deprecated since Python 3.2, so this change doesn't break the installation for the previous Python version (I checked with Python>=3.9)

Closes #204 