### PR TITLE
Fix normalization units of Powerlaw_Eflux

### DIFF
--- a/astromodels/functions/functions_1D/powerlaws.py
+++ b/astromodels/functions/functions_1D/powerlaws.py
@@ -233,9 +233,9 @@ class Powerlaw_Eflux(Function1D, metaclass=FunctionMeta):
         self.a.unit = x_unit
         self.b.unit = x_unit
 
-        # The normalization has the same units as the y
+        # The flux is the integral of E*F(E) over E, so:
 
-        self.F.unit = y_unit * x_unit
+        self.F.unit = y_unit * x_unit * x_unit
 
     # noinspection PyPep8Naming
     def evaluate(self, x, F, piv, index, a, b):


### PR DESCRIPTION
The `Powerlaw_EFlux._set_units()` was setting the normalization units missing the energy part of the integrand. It should have an additional factor of `x_units` compared to `Powerlaw_flux._set_units()`.

The following code

```
from astromodels import Powerlaw_Eflux, PointSource
from astropy import units as u

l = 255.073637
b = 81.659766

a = 100. * u.keV
b2 = 10000. * u.keV
F = 0.01 * u.erg/ u.cm / u.cm / u.s
index = -1.5

spectrum = Powerlaw_Eflux(F = F.value, index = index, a = a.value, b = b2.value)

spectrum.F.unit = F.unit
spectrum.a.unit = a.unit
spectrum.b.unit = b2.unit

source = PointSource("source",         # Name of source (arbitrary, but needs to be unique)
                     l = l,                        # Longitude (deg)
                     b = b,                        # Latitude (deg)
                     spectral_shape = spectrum)    # Spectral model
```

Was producing the error:
```
Traceback (most recent call last):
  File "/Users/imartin5/Library/Application Support/JetBrains/PyCharmCE2024.3/scratches/scratch_9.py", line 18, in <module>
    source = PointSource("source",         # Name of source (arbitrary, but needs to be unique)
  File "/Users/imartin5/software/astromodels/astromodels/sources/point_source.py", line 178, in __init__
    component.shape.set_units(x_unit, y_unit)
  File "/Users/imartin5/software/astromodels/astromodels/functions/function.py", line 1391, in set_units
    new_units = self._set_units(in_x_unit, in_y_unit)
  File "/Users/imartin5/software/astromodels/astromodels/functions/functions_1D/powerlaws.py", line 238, in _set_units
    self.F.unit = y_unit * x_unit
  File "/Users/imartin5/software/astromodels/astromodels/core/node_type.py", line 401, in __setattr__
    return super().__setattr__(name, value)
  File "/Users/imartin5/software/astromodels/astromodels/core/parameter.py", line 365, in _set_unit
    raise CannotConvertValueToNewUnits()
astromodels.core.parameter.CannotConvertValueToNewUnits
```

With this fix it no longer produces that error. Unfortunately, it still produces another unrelated error due to #92.