### PR TITLE
Update Parameter bounds when changing units

### DIFF
--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -345,7 +345,10 @@ class ParameterBase(Node):
 
             try:
 
-                self.value = self.as_quantity.to(new_unit).value
+                factor = self._unit.to(new_unit)
+                self.value *= factor
+                self.min_value *= factor
+                self.max_value *= factor
 
             except u.UnitConversionError:
 

--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -346,13 +346,14 @@ class ParameterBase(Node):
             try:
 
                 factor = self._unit.to(new_unit)
-                self.value *= factor
 
                 if self.min_value is not None:
                     self.min_value *= factor
 
                 if self.max_value is not None:
                     self.max_value *= factor
+
+                self.value *= factor
 
             except u.UnitConversionError:
 

--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -347,8 +347,12 @@ class ParameterBase(Node):
 
                 factor = self._unit.to(new_unit)
                 self.value *= factor
-                self.min_value *= factor
-                self.max_value *= factor
+
+                if self.min_value is not None:
+                    self.min_value *= factor
+
+                if self.max_value is not None:
+                    self.max_value *= factor
 
             except u.UnitConversionError:
 

--- a/astromodels/tests/test_parameter.py
+++ b/astromodels/tests/test_parameter.py
@@ -301,6 +301,15 @@ def test_set_units():
 
     p.display()
 
+    # Check that the value and bounds are updated when we set a new unit
+    p = Parameter("test_parameter", 1.0, min_value=0, max_value=1e5, unit=u.MeV)
+    p.unit = u.eV
+    assert p.value == 1e6
+    assert p.min_value == 0.0
+    assert p.max_value == 1e11
+
+    p.display()
+
 
 def test_set_within_bounds_units():
 


### PR DESCRIPTION
Closes #92 

This performs the same conversion for `min_value`/`max_value` as is was already being done for `value`.