### PR TITLE
Fix Xspec install for full xspec from conda

### DIFF
--- a/astromodels/xspec/factory.py
+++ b/astromodels/xspec/factory.py
@@ -120,6 +120,13 @@ def find_model_dat():
     # Now model.dat should be in $HEADAS/../spectral/manager
 
     final_path = os.path.join(inferred_path, "spectral", "manager", "model.dat")
+    if not os.path.exists(final_path):
+        warnings.warn(
+            f"Could not find Xspec model definition in {final_path}. If you installed "
+            "Xspec via conda not using xspec-modelsonly it may be in a different path. "
+            "We will check..."
+        )
+        final_path = os.path.join(headas_env, "spectral", "manager", "model.dat")
 
     # Check that model.dat exists
 


### PR DESCRIPTION
looks for the model.dat in $HEADAS/spectral/manager/ instead of $HEADAS/../spectral/manager/ when the latter did not succeed - this is the case when installing xspec following the [official installation instructions](https://heasarc.gsfc.nasa.gov/docs/software/conda.html) using conda