### PR TITLE
Fix error in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [project]
     name = "astromodels"
     description = """Astromodels contains models to be used in likelihood or Bayesian 
-    analysis in astronomy""""
+    analysis in astronomy"""
     readme = "README.md"
     license = "BSD-3-Clause"
     license-files = ["LICENSE"]


### PR DESCRIPTION
Fix error in pyproject.toml:

Mismatched quotation marks.