### PR TITLE
Fix and update readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-   os: ubuntu-22.04
+   os: ubuntu-24.04
    tools:
-      python: "3.9"
+      python: "3.11"
 
 python:
    install:
@@ -13,4 +13,5 @@ python:
        extra_requirements:
         - docs
         
-
+sphinx:
+  configuration: docs/conf.py


### PR DESCRIPTION
readthedocs deprecated the non-explicit use of sphinx configuration file [see here](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)

Also updated the build OS to ubuntu 24.04 and python 3.11