### PR TITLE
Fix astropy units

### DIFF
--- a/astromodels/core/thread_safe_unit_format.py
+++ b/astromodels/core/thread_safe_unit_format.py
@@ -15,9 +15,9 @@ from astropy.units.format.base import Base
 try:
     from astropy.units.enums import DeprecatedUnitAction
 except ModuleNotFoundError:
-    from enum import StrEnum, auto
+    from enum import Enum, auto
 
-    class DeprecatedUnitAction(StrEnum):
+    class DeprecatedUnitAction(Enum):
         WARN = auto()
 
 


### PR DESCRIPTION
adds new keyword to `to_string` method, introduced in `astropy==7.2.0`.

Fakes minimal `StrEnum` class for `astropy<7.2.0`