### PR TITLE
Add integrate() function

### DIFF
--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -15,6 +15,7 @@ from typing import Dict, List, Optional, Tuple
 import astropy.units as u
 import numba as nb
 import numpy as np
+from scipy.integrate import quad
 from yaml.reader import ReaderError
 
 from astromodels.core.memoization import memoize
@@ -1544,6 +1545,25 @@ class Function1D(Function):
         b = self(x * (1 + epsilon))
 
         return _local_deriv(a, b, epsilon)
+
+    def integrate(self, a, b, *args, **kwargs):
+        """
+        Integrates the function from a to b. If an analytically integral is available
+        will use this, otherwise fall back to the numerical integration using scipys
+        quadrature rule.
+
+        :param a: lower integration boundary
+        :type a: float or astropy.Quantity
+        :param b: upper integration boundary
+        :type b: float or astropy.Quantity
+        :param args: additional positional arguments for scipy.integrate.quad
+        :type args: list
+        :param kwargs: additional keyword aguments for scipy.integrate.quad
+        :type kwargs: dict
+
+        returns: value of integral
+        """
+        return quad(self.__call__, a, b, *args, **kwargs)[0]
 
 
 @nb.njit

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1700,7 +1700,23 @@ class Function2D(Function):
         # microseconds or so), so we perform this transformation only when strictly
         # required
 
-        assert type(x) is type(y), "You have to use the same type for x and y"
+        if not type(x) is type(y):
+            if type(x) in [float, int, str] or type(y) is [float, int, str]:
+                x_type = type(x)
+                y_type = type(y)
+                try:
+                    x = float(x)
+                    y = float(y)
+                except Exception as e:
+                    raise TypeError(
+                        "You have to use the same type for x and y or they need to be "
+                        f"convertible to float. Got {x_type} and {y_type}"
+                    ) from e
+            else:
+                raise TypeError(
+                    "You have to use the same type for x and y or they need to be "
+                    f"convertible to float. Got {x_type} and {y_type}"
+                )
 
         if isinstance(x, np.ndarray):
 

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1565,6 +1565,31 @@ class Function1D(Function):
 
         returns: value of integral
         """
+        if isinstance(a, u.Quantity) and isinstance(b, u.Quantity):
+            pass
+
+        elif (isinstance(a, u.Quantity) and not isinstance(b, u.Quantity)) or (
+            not isinstance(a, u.Quantity) and isinstance(b, u.Quantity)
+        ):
+            raise TypeError(
+                "a and b must either be astropy Quantities or floats. "
+                "You can not mix."
+            )
+
+        return self.integral(a, b, *args, **kwargs)
+
+    def integral(self, a, b, *args, **kwargs):
+        """
+        The actual integral defintion. Needs to be overwritten for analytical integrals
+        :param a: lower integration boundary
+        :type a: float
+        :param b: upper integration boundary
+        :type b: float
+        :param args: additional positional arguments for scipy.integrate.quad
+        :type args: list
+        :param kwargs: additional keyword aguments for scipy.integrate.quad
+        :type kwargs: dict
+        """
         res = quad(self.__call__, a, b, *args, **kwargs)
         self._integral_numerical_error = res[1]
         return res[0]

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1566,7 +1566,15 @@ class Function1D(Function):
         returns: value of integral
         """
         if isinstance(a, u.Quantity) and isinstance(b, u.Quantity):
-            pass
+            try:
+                a = a.to(self._x_unit).value
+                b = b.to(self._x_unit).value
+            except Exception as e:
+                raise ValueError(
+                    "You integral boundary unit must be converatble to "
+                    f"{self._x_unit}."
+                ) from e
+            return self.integral(a, b, *args, **kwargs) * self._y_unit * self._x_unit
 
         elif (isinstance(a, u.Quantity) and not isinstance(b, u.Quantity)) or (
             not isinstance(a, u.Quantity) and isinstance(b, u.Quantity)
@@ -1575,8 +1583,8 @@ class Function1D(Function):
                 "a and b must either be astropy Quantities or floats. "
                 "You can not mix."
             )
-
-        return self.integral(a, b, *args, **kwargs)
+        else:
+            return self.integral(a, b, *args, **kwargs)
 
     def integral(self, a, b, *args, **kwargs):
         """

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1305,6 +1305,8 @@ class Function(Node):
 
 
 class Function1D(Function):
+    _integral_error = None
+
     def __init__(
         self,
         name: Optional[str] = None,
@@ -1563,7 +1565,16 @@ class Function1D(Function):
 
         returns: value of integral
         """
-        return quad(self.__call__, a, b, *args, **kwargs)[0]
+        res = quad(self.__call__, a, b, *args, **kwargs)
+        self._integral_error = res[1]
+        return res[0]
+
+    @property
+    def integral_error(self):
+        if hasattr(self, "_integral_error"):
+            return self._integral_error
+        else:
+            return None
 
 
 @nb.njit

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1305,7 +1305,7 @@ class Function(Node):
 
 
 class Function1D(Function):
-    _integral_error = None
+    _integral_numerical_error = None
 
     def __init__(
         self,
@@ -1566,13 +1566,13 @@ class Function1D(Function):
         returns: value of integral
         """
         res = quad(self.__call__, a, b, *args, **kwargs)
-        self._integral_error = res[1]
+        self._integral_numerical_error = res[1]
         return res[0]
 
     @property
-    def integral_error(self):
-        if hasattr(self, "_integral_error"):
-            return self._integral_error
+    def integral_numerical_error(self):
+        if hasattr(self, "_integral_numerical_error"):
+            return self._integral_numerical_error
         else:
             return None
 

--- a/astromodels/functions/functions_1D/functions.py
+++ b/astromodels/functions/functions_1D/functions.py
@@ -188,6 +188,17 @@ class StepFunction(Function1D, metaclass=FunctionMeta):
 
         return result
 
+    def integrate(self, a, b):
+        sign = 1
+        if a > b:
+            a, b = b, a
+            sign = -1
+        if a < self.lower_bound:
+            a = self.lower_bound
+        if b > self.upper_bound:
+            b = self.upper_bound
+        return sign * (b - a) * self._value
+
 
 class StepFunctionUpper(Function1D, metaclass=FunctionMeta):
     r"""
@@ -247,12 +258,6 @@ class StepFunctionUpper(Function1D, metaclass=FunctionMeta):
         return result
 
 
-# noinspection PyPep8Naming
-
-
-# noinspection PyPep8Naming
-
-
 class Sin(Function1D, metaclass=FunctionMeta):
     r"""
     description :
@@ -305,6 +310,16 @@ class Sin(Function1D, metaclass=FunctionMeta):
     def evaluate(self, x, K, f, phi):
         return K * np.sin(2 * np.pi * f * x + phi)
 
+    def integrate(self, a, b):
+        return (
+            -self.K
+            / (2 * np.pi * self.f)
+            * (
+                np.cos(2 * np.pi * self.f * b + self.phi)
+                - np.cos(2 * np.pi * self.f * a + self.phi)
+            )
+        )
+
 
 class DiracDelta(Function1D, metaclass=FunctionMeta):
     r"""
@@ -348,6 +363,12 @@ class DiracDelta(Function1D, metaclass=FunctionMeta):
         out[x == zero_point] = value
 
         return out
+
+    def integrate(self, a, b):
+        if a <= self.zero_point <= b:
+            return self.value
+        else:
+            return 0
 
 
 if has_naima:

--- a/astromodels/functions/functions_1D/functions.py
+++ b/astromodels/functions/functions_1D/functions.py
@@ -193,11 +193,11 @@ class StepFunction(Function1D, metaclass=FunctionMeta):
         if a > b:
             a, b = b, a
             sign = -1
-        if a < self.lower_bound:
-            a = self.lower_bound
-        if b > self.upper_bound:
-            b = self.upper_bound
-        return sign * (b - a) * self._value
+        if a < self.lower_bound.value:
+            a = self.lower_bound.value
+        if b > self.upper_bound.value:
+            b = self.upper_bound.value
+        return sign * (b - a) * self.value.value
 
 
 class StepFunctionUpper(Function1D, metaclass=FunctionMeta):
@@ -312,11 +312,11 @@ class Sin(Function1D, metaclass=FunctionMeta):
 
     def integral(self, a, b):
         return (
-            -self.K
-            / (2 * np.pi * self.f)
+            -self.K.value
+            / (2 * np.pi * self.f.value)
             * (
-                np.cos(2 * np.pi * self.f * b + self.phi)
-                - np.cos(2 * np.pi * self.f * a + self.phi)
+                np.cos(2 * np.pi * self.f.value * b + self.phi.value)
+                - np.cos(2 * np.pi * self.f.value * a + self.phi.value)
             )
         )
 
@@ -365,8 +365,8 @@ class DiracDelta(Function1D, metaclass=FunctionMeta):
         return out
 
     def integral(self, a, b):
-        if a <= self.zero_point <= b:
-            return self.value
+        if a <= self.zero_point.value <= b:
+            return self.value.value
         else:
             return 0
 

--- a/astromodels/functions/functions_1D/functions.py
+++ b/astromodels/functions/functions_1D/functions.py
@@ -188,7 +188,7 @@ class StepFunction(Function1D, metaclass=FunctionMeta):
 
         return result
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         sign = 1
         if a > b:
             a, b = b, a
@@ -310,7 +310,7 @@ class Sin(Function1D, metaclass=FunctionMeta):
     def evaluate(self, x, K, f, phi):
         return K * np.sin(2 * np.pi * f * x + phi)
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         return (
             -self.K
             / (2 * np.pi * self.f)
@@ -364,7 +364,7 @@ class DiracDelta(Function1D, metaclass=FunctionMeta):
 
         return out
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         if a <= self.zero_point <= b:
             return self.value
         else:

--- a/astromodels/functions/functions_1D/polynomials.py
+++ b/astromodels/functions/functions_1D/polynomials.py
@@ -40,6 +40,9 @@ class Constant(Function1D, metaclass=FunctionMeta):
 
         return k * np.ones(np.shape(x))
 
+    def integrate(self, a, b):
+        return self.k.value * (b - a)
+
 
 class Line(Function1D, metaclass=FunctionMeta):
     r"""
@@ -72,6 +75,13 @@ class Line(Function1D, metaclass=FunctionMeta):
 
     def evaluate(self, x, a, b):
         return b * x + a
+
+    def integrate(self, a, b, use_scipy=False):
+        if use_scipy:
+            return super().integrate(a, b)
+        return self.a.value * (b - a) + 0.5 * self.b.value * (
+            np.power(b, 2) - np.power(a, 2)
+        )
 
 
 class Quadratic(Function1D, metaclass=FunctionMeta):
@@ -113,6 +123,13 @@ class Quadratic(Function1D, metaclass=FunctionMeta):
 
     def evaluate(self, x, a, b, c):
         return a + b * x + c * x * x
+
+    def integrate(self, a, b):
+        return (
+            self.a.value * (b - a)
+            + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))
+            + 1 / 3 * self.c.value * (np.power(b, 3) - np.power(a, 3))
+        )
 
 
 class Cubic(Function1D, metaclass=FunctionMeta):
@@ -166,6 +183,14 @@ class Cubic(Function1D, metaclass=FunctionMeta):
         x3 = x2 * x
 
         return a + b * x + c * x2 + d * x3
+
+    def integrate(self, a, b):
+        return (
+            self.a.value * (b - a)
+            + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))
+            + 1 / 3 * self.c.value * (np.power(b, 3) - np.power(a, 3))
+            + 0.25 * self.d.value * (np.power(b, 4) - np.power(a, 4))
+        )
 
 
 class Quartic(Function1D, metaclass=FunctionMeta):
@@ -228,3 +253,12 @@ class Quartic(Function1D, metaclass=FunctionMeta):
         x4 = x3 * x
 
         return a + b * x + c * x2 + d * x3 + e * x4
+
+    def integrate(self, a, b):
+        return (
+            self.a.value * (b - a)
+            + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))
+            + 1 / 3 * self.c.value * (np.power(b, 3) - np.power(a, 3))
+            + 0.25 * self.d.value * (np.power(b, 4) - np.power(a, 4))
+            + 0.2 * self.e.value * (np.power(b, 5) - np.power(a, 5))
+        )

--- a/astromodels/functions/functions_1D/polynomials.py
+++ b/astromodels/functions/functions_1D/polynomials.py
@@ -40,7 +40,7 @@ class Constant(Function1D, metaclass=FunctionMeta):
 
         return k * np.ones(np.shape(x))
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         return self.k.value * (b - a)
 
 
@@ -76,9 +76,9 @@ class Line(Function1D, metaclass=FunctionMeta):
     def evaluate(self, x, a, b):
         return b * x + a
 
-    def integrate(self, a, b, use_scipy=False):
+    def integral(self, a, b, use_scipy=False):
         if use_scipy:
-            return super().integrate(a, b)
+            return super().integral(a, b)
         return self.a.value * (b - a) + 0.5 * self.b.value * (
             np.power(b, 2) - np.power(a, 2)
         )
@@ -124,7 +124,7 @@ class Quadratic(Function1D, metaclass=FunctionMeta):
     def evaluate(self, x, a, b, c):
         return a + b * x + c * x * x
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         return (
             self.a.value * (b - a)
             + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))
@@ -184,7 +184,7 @@ class Cubic(Function1D, metaclass=FunctionMeta):
 
         return a + b * x + c * x2 + d * x3
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         return (
             self.a.value * (b - a)
             + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))
@@ -254,7 +254,7 @@ class Quartic(Function1D, metaclass=FunctionMeta):
 
         return a + b * x + c * x2 + d * x3 + e * x4
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         return (
             self.a.value * (b - a)
             + 0.5 * self.b.value * (np.power(b, 2) - np.power(a, 2))

--- a/astromodels/functions/functions_1D/powerlaws.py
+++ b/astromodels/functions/functions_1D/powerlaws.py
@@ -87,7 +87,7 @@ class Powerlaw(Function1D, metaclass=FunctionMeta):
 
         return result * unit_
 
-    def integrate(self, a, b):
+    def integral(self, a, b):
         if isinstance(a, astropy_units.Quantity) and isinstance(
             b, astropy_units.Quantity
         ):
@@ -1055,7 +1055,7 @@ class Band_Calderone(Function1D, metaclass=FunctionMeta):
 
         Esplit = (alpha - beta) * Ec
 
-        # Evaluate model integrated flux and normalization
+        # Evaluate model integrald flux and normalization
 
         if isinstance(alpha, astropy_units.Quantity):
 

--- a/astromodels/functions/functions_1D/powerlaws.py
+++ b/astromodels/functions/functions_1D/powerlaws.py
@@ -69,7 +69,6 @@ class Powerlaw(Function1D, metaclass=FunctionMeta):
 
         self.K.unit = y_unit
 
-    # noinspection PyPep8Naming
     def evaluate(self, x, K, piv, index):
 
         if isinstance(x, astropy_units.Quantity):
@@ -87,6 +86,30 @@ class Powerlaw(Function1D, metaclass=FunctionMeta):
         result = nb_func.plaw_eval(x_, K_, index_, piv_)
 
         return result * unit_
+
+    def integrate(self, a, b):
+        if isinstance(a, astropy_units.Quantity) and isinstance(
+            b, astropy_units.Quantity
+        ):
+            index_ = self.index.value
+            K_ = self.K.value
+            piv_ = self.piv.value
+            a_ = a.value
+            b_ = b.value
+
+            unit_ = self.y_unit
+
+        else:
+            unit_ = 1.0
+            K_, piv_, a_, b_, index_ = (
+                self.K.value,
+                self.piv.value,
+                a,
+                b,
+                self.index.value,
+            )
+
+        return nb_func.plaw_integral(a_, b_, K_, index_, piv_) * unit_
 
 
 # noinspection PyPep8Naming

--- a/astromodels/functions/numba_functions.py
+++ b/astromodels/functions/numba_functions.py
@@ -258,3 +258,13 @@ def dbl_sbpl(x, K, a1, a2, b1, xp, xb, n1, n2, xpiv):
     )
 
     return K * out
+
+
+@nb.njit(fastmath=True, cache=_cache_functions)
+def plaw_integral(a, b, K, i, piv):
+    if i != -1:
+        return K * piv * (b / piv) ** (i + 1) / (i + 1) - K * piv * (a / piv) ** (
+            i + 1
+        ) / (i + 1)
+    else:
+        return K * piv * np.log(b / piv) - K * piv * np.log(a / piv)

--- a/astromodels/tests/test_functions.py
+++ b/astromodels/tests/test_functions.py
@@ -1085,3 +1085,51 @@ def test_complex_composites():
 def test_cpl_ep():
     test = Cutoff_powerlaw_Ep()
     assert np.isclose(test.evaluate(np.array([1]), 1, 1, -2.0, 100), 1), ""
+
+
+def test_call_parameters():
+    """
+    Tests if we can use different types for x and y in a Function2D for calling
+    """
+
+    class TestFunc2D(Function2D, metaclass=FunctionMeta):
+        r"""
+
+        description: useless
+
+        latex : $ a * x + b * y$
+
+        parameters :
+
+            a :
+
+                desc : blah
+                initial value : 1
+
+
+            b :
+
+                desc : intercept
+                initial value : 1
+
+            c :
+
+                desc : dumb
+                initial value : 1
+
+        """
+
+        def _set_units(self, x_unit, y_unit, z_unit):
+            self.a.unit = y_unit / x_unit
+            self.b.unit = y_unit
+
+        def evaluate(self, x, y, a, b, c):
+            return a * x + b * y
+
+    func = TestFunc2D()
+    with pytest.raises(TypeError):
+        func(0, func)
+    with pytest.raises(TypeError):
+        func(0, "abc")
+    _ = func(0, "0")
+    _ = func(0.0, 0)

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -1,4 +1,4 @@
-from astromodels.functions import Powerlaw, Line
+from astromodels.functions import Powerlaw, Line, Constant, get_polynomial
 import numpy as np
 
 
@@ -7,11 +7,20 @@ def test_analytical_integral():
     pl.index.value = -2
     assert np.isclose(pl.integrate(0.1, 1), 9)
     assert pl.integral_numerical_error is None
+    c = Constant()
+    c.k.value = 1
+    assert np.isclose(c.integrate(0, 1), 1)
+
+    for order in range(2, 5, 1):
+        pol = get_polynomial(order)
+        assert np.isclose(
+            pol.integrate(0, 1), np.sum([1 / (i + 1) for i in range(order + 1)])
+        )
 
 
 def test_numerical_integral():
     line = Line()
     line.a.value = 0
     line.b.value = 1
-    assert np.isclose(line.integrate(0, 1), 0.5)
+    assert np.isclose(line.integrate(0, 1, use_scipy=True), 0.5)
     assert line.integral_numerical_error is not None

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -1,6 +1,5 @@
 import astropy.units as u
 import warnings
-from scipy.integrate import IntegrationWarning
 import numpy as np
 import pytest
 from astromodels.functions.function import _known_functions, Function1D
@@ -29,10 +28,17 @@ def test_integrate_function1D():
     for k, v in _known_functions.items():
         # exclude the functions that need external input for now
         if issubclass(v, Function1D):
-            if k in ["GenericFunction", "_ComplexTestFunction", "TemplateModel"]:
+            if k in [
+                "GenericFunction",
+                "_ComplexTestFunction",
+                "TemplateModel",
+            ] or (
+                k.startswith("XS_") and k not in ["XS_agauss"]
+            ):  # do not test the XSPEC functions
                 continue
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
+                # test that the function exists
                 _ = v().integrate(1, 2)
 
 

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -6,6 +6,7 @@ def test_analytical_integral():
     pl = Powerlaw()
     pl.index.value = -2
     assert np.isclose(pl.integrate(0.1, 1), 9)
+    assert pl.integral_error is None
 
 
 def test_numerical_integral():
@@ -13,3 +14,4 @@ def test_numerical_integral():
     line.a.value = 0
     line.b.value = 1
     assert np.isclose(line.integrate(0, 1), 0.5)
+    assert line.integral_error is not None

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -1,5 +1,8 @@
-from astromodels.functions import Powerlaw, Line, Constant, get_polynomial
+import astropy.units as u
 import numpy as np
+import pytest
+
+from astromodels.functions import Constant, Line, Powerlaw, get_polynomial
 
 
 def test_analytical_integral():
@@ -24,3 +27,19 @@ def test_numerical_integral():
     line.b.value = 1
     assert np.isclose(line.integrate(0, 1, use_scipy=True), 0.5)
     assert line.integral_numerical_error is not None
+    assert np.isclose(line.integrate(1, 0, use_scipy=True), -0.5)
+
+
+def test_quantities():
+    line = Line()
+    line.set_units(u.keV, u.Unit("keV-1 cm-2 s-1"))
+    line.a.value = 0
+    line.b.value = 1
+    int_val = line.integrate(0 * u.keV, 1 * u.keV)
+    assert np.isclose(int_val.value, 0.5)
+    assert int_val.unit == u.Unit("cm-2 s-1")
+
+    with pytest.raises(ValueError):
+        _ = line.integrate(1 * u.keV, 1 * u.m)
+    with pytest.raises(TypeError):
+        _ = line.integrate(1 * u.keV, 1)

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -1,0 +1,15 @@
+from astromodels.functions import Powerlaw, Line
+import numpy as np
+
+
+def test_analytical_integral():
+    pl = Powerlaw()
+    pl.index.value = -2
+    assert np.isclose(pl.integrate(0.1, 1), 9)
+
+
+def test_numerical_integral():
+    line = Line()
+    line.a.value = 0
+    line.b.value = 1
+    assert np.isclose(line.integrate(0, 1), 0.5)

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -1,6 +1,10 @@
 import astropy.units as u
+import warnings
+from scipy.integrate import IntegrationWarning
 import numpy as np
 import pytest
+from astromodels.functions.function import _known_functions, Function1D
+
 
 from astromodels.functions import Constant, Line, Powerlaw, get_polynomial
 
@@ -19,6 +23,17 @@ def test_analytical_integral():
         assert np.isclose(
             pol.integrate(0, 1), np.sum([1 / (i + 1) for i in range(order + 1)])
         )
+
+
+def test_integrate_function1D():
+    for k, v in _known_functions.items():
+        # exclude the functions that need external input for now
+        if issubclass(v, Function1D):
+            if k in ["GenericFunction", "_ComplexTestFunction", "TemplateModel"]:
+                continue
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                _ = v().integrate(1, 2)
 
 
 def test_numerical_integral():

--- a/astromodels/tests/test_integration.py
+++ b/astromodels/tests/test_integration.py
@@ -6,7 +6,7 @@ def test_analytical_integral():
     pl = Powerlaw()
     pl.index.value = -2
     assert np.isclose(pl.integrate(0.1, 1), 9)
-    assert pl.integral_error is None
+    assert pl.integral_numerical_error is None
 
 
 def test_numerical_integral():
@@ -14,4 +14,4 @@ def test_numerical_integral():
     line.a.value = 0
     line.b.value = 1
     assert np.isclose(line.integrate(0, 1), 0.5)
-    assert line.integral_error is not None
+    assert line.integral_numerical_error is not None

--- a/docs/md/Functions_tutorial.md
+++ b/docs/md/Functions_tutorial.md
@@ -6,7 +6,7 @@ jupyter:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.11.2
+      jupytext_version: 1.19.1
   kernelspec:
     display_name: Python 3
     language: python
@@ -215,6 +215,36 @@ we will end up with two independent sets of parameters for the two power laws. T
 ```python
 print(len(another_composite.parameters)) # 6 parameters
 print(len(another_composite2.parameters)) # 9 parameters
+```
+
+## Integrating Functions
+
+### Function1D
+Since `astromodels v2.6.1` we provide the `.integrate(a, b)` function on 1D functions.
+This returns the analytical integral from `a` to `b` if the integral is known and otherwise
+uses `scipy.integrate.quad` to numerically integrate the function.
+The latter is the default and in case you want to provide your own analytical solution
+for your custom function you need to overwrite it.
+
+```python
+from astromodels.functions import Powerlaw
+
+pl = Powerlaw()
+pl.index.value = -2
+pl.K.value = 1
+pl.piv.value = 1
+print(pl.integrate(a = 1, b = 10))
+```
+
+### Function2D and Function3D
+
+For multidimensional functions we do not provide a integrate function, as the user might
+want to only integrate over one or two dimensions.
+However doing that numerically with `scipy.integrate.nquad` is straigforward:
+
+```python
+from scipy.integrate import nquad
+
 ```
 
 ## Creating custom functions

--- a/docs/md/Functions_tutorial.md
+++ b/docs/md/Functions_tutorial.md
@@ -224,7 +224,7 @@ Since `astromodels v2.6.1` we provide the `.integrate(a, b)` function on 1D func
 This returns the analytical integral from `a` to `b` if the integral is known and otherwise
 uses `scipy.integrate.quad` to numerically integrate the function.
 The latter is the default and in case you want to provide your own analytical solution
-for your custom function you need to overwrite it.
+for your custom function you need to overwrite the `.integral` function.
 
 ```python
 from astromodels.functions import Powerlaw
@@ -236,6 +236,38 @@ pl.piv.value = 1
 print(pl.integrate(a = 1, b = 10))
 ```
 
+For defining your own analytical integral, this suffices:
+```python
+import numpy as np
+class JustALine(Function1D, metaclass=FunctionMeta):
+    r"""
+    description :
+        A linear function
+    latex : $ b * x + a $
+    parameters :
+        a :
+            desc :  intercept
+            initial value : 0
+        b :
+            desc : coeff
+            initial value : 1
+    """
+    def _set_units(self,x_unit,y_unit):
+        self.a.unit = y_unit
+        self.b.unit = y_unit / x_unit
+
+    def evaluate(self, x, a, b):
+        return b * x + a
+
+    def integral(self, a, b):
+        return self.a.value * (b - a) + 0.5 * self.b.value * (
+            np.power(b, 2) - np.power(a, 2)
+        )
+
+jl = JustALine()
+print(jl.integrate(0,1))
+```
+
 ### Function2D and Function3D
 
 For multidimensional functions we do not provide a integrate function, as the user might
@@ -243,8 +275,30 @@ want to only integrate over one or two dimensions.
 However doing that numerically with `scipy.integrate.nquad` is straigforward:
 
 ```python
-from scipy.integrate import nquad
+from scipy.integrate import nquad,quad
+from astromodels.functions import Disk_on_sphere
 
+disk = Disk_on_sphere()
+disk.radius = 15
+```
+
+Let's first integrate over the first coordinate:
+```python
+val, err = quad(disk,0,15,args=(0))
+print(val)
+```
+In case you want to integrate over the second one, you need to wrap the function:
+```python
+wrapper = lambda y,x: disk(x,y)
+val, err = quad(wrapper,0,15,args=(0))
+print(val)
+```
+And in case you want to perform a multidimensional integration you can use something like
+this. This might be a bit slow so we are fine with an rough estimate: 
+
+```python
+val, err = nquad(disk,((0,15),(0,15)),opts ={"epsabs": 1e-2,"limit":10})
+print(val)
 ```
 
 ## Creating custom functions


### PR DESCRIPTION
Adds an integrate functionality - use analytical function if available and fall back to numerical integration

Resolves #199 

## ToDos:
- [x] add all known analytical integrals
- [x] fix usage of quantities
- [x] add 2D and 3D integration docs
- [x] check if replaceable: https://github.com/threeML/astromodels/blob/c4149eb478fba9143f030ba47d83cc881c6e8979/astromodels/sources/point_source.py#L261-L263

<!-- readthedocs-preview astromodels start -->
----
📚 Documentation preview 📚: https://astromodels--257.org.readthedocs.build/en/257/

<!-- readthedocs-preview astromodels end -->