### PR TITLE
Use builtin dicts instead of OrderedDicts

### DIFF
--- a/astromodels/core/memoization.py
+++ b/astromodels/core/memoization.py
@@ -41,7 +41,7 @@ def memoize(method):
     :return: the decorated method
     """
 
-    cache = method.cache = collections.OrderedDict()
+    cache = method.cache = dict()
 
     # Put these two methods in the local space (faster)
     _get = cache.get

--- a/astromodels/core/memoization.py
+++ b/astromodels/core/memoization.py
@@ -1,4 +1,3 @@
-import collections
 import contextlib
 import functools
 

--- a/astromodels/core/model.py
+++ b/astromodels/core/model.py
@@ -67,9 +67,9 @@ class _LinkedFunctionContainer:
 
     def output(self, rich=True):
 
-        this_dict = collections.OrderedDict()
+        this_dict = dict()
 
-        tmp = collections.OrderedDict()
+        tmp = dict()
         tmp["linked function"] = self.linked_path
         tmp["internal name"] = self.internal_name
         this_dict[self.function_name] = tmp
@@ -95,15 +95,15 @@ class Model(Node):
 
         # Dictionary to keep point sources
 
-        self._point_sources: Dict[str, PointSource] = collections.OrderedDict()
+        self._point_sources: Dict[str, PointSource] = dict()
 
         # Dictionary to keep extended sources
 
-        self._extended_sources: Dict[str, ExtendedSource] = collections.OrderedDict()
+        self._extended_sources: Dict[str, ExtendedSource] = dict()
 
         # Dictionary to keep particle sources
 
-        self._particle_sources: Dict[str, ParticleSource] = collections.OrderedDict()
+        self._particle_sources: Dict[str, ParticleSource] = dict()
 
         # Loop over the provided sources and process them
 
@@ -234,7 +234,7 @@ class Model(Node):
 
         # Filter selecting only free parameters
 
-        free_parameters_dictionary: Dict[str, Parameter] = collections.OrderedDict()
+        free_parameters_dictionary: Dict[str, Parameter] = dict()
 
         for parameter_name, parameter in list(self._parameters.items()):
 
@@ -272,7 +272,7 @@ class Model(Node):
 
         # Filter selecting only free parameters
 
-        linked_parameter_dictionary: Dict[str, Parameter] = collections.OrderedDict()
+        linked_parameter_dictionary: Dict[str, Parameter] = dict()
 
         for parameter_name, parameter in list(self._parameters.items()):
 
@@ -427,7 +427,7 @@ class Model(Node):
     def point_sources(self) -> Dict[str, PointSource]:
         """Returns the dictionary of all defined point sources.
 
-        :return: collections.OrderedDict()
+        :return: dict()
         """
         return self._point_sources
 
@@ -435,7 +435,7 @@ class Model(Node):
     def extended_sources(self) -> Dict[str, ExtendedSource]:
         """Returns the dictionary of all defined extended sources.
 
-        :return: collections.OrderedDict()
+        :return: dict()
         """
         return self._extended_sources
 
@@ -443,7 +443,7 @@ class Model(Node):
     def particle_sources(self) -> Dict[str, ParticleSource]:
         """Returns the dictionary of all defined particle sources.
 
-        :return: collections.OrderedDict()
+        :return: dict()
         """
         return self._particle_sources
 
@@ -453,11 +453,11 @@ class Model(Node):
     ) -> Dict[str, Union[PointSource, ExtendedSource, ParticleSource]]:
         """Returns a dictionary containing all defined sources (of any kind)
 
-        :return: collections.OrderedDict()
+        :return: dict()
         """
 
         sources: Dict[str, Union[PointSource, ExtendedSource, ParticleSource]] = (
-            collections.OrderedDict()
+            dict()
         )
 
         for d in (
@@ -511,7 +511,7 @@ class Model(Node):
         """
 
         tempmodel = Model(self[source_name])
-        unlinked_parameters = collections.OrderedDict()
+        unlinked_parameters = dict()
 
         for par in self.linked_parameters.values():
 
@@ -722,7 +722,7 @@ class Model(Node):
 
         # Table with the summary of the various kind of sources
         sources_summary = pd.DataFrame.from_dict(
-            collections.OrderedDict(
+            dict(
                 [
                     ("Point sources", [self.get_number_of_point_sources()]),
                     (
@@ -750,7 +750,7 @@ class Model(Node):
         # Summary of free parameters
         if len(free_parameters) > 0:
 
-            parameter_dict = collections.OrderedDict()
+            parameter_dict = dict()
 
             for parameter_name, parameter in list(free_parameters.items()):
                 # Generate table with only a minimal set of info
@@ -767,7 +767,7 @@ class Model(Node):
                     this_name = long_path_formatter(parameter_name, 40)
 
                 d = parameter.to_dict()
-                parameter_dict[this_name] = collections.OrderedDict()
+                parameter_dict[this_name] = dict()
 
                 for key in ["value", "unit", "min_value", "max_value"]:
 
@@ -785,7 +785,7 @@ class Model(Node):
 
         if len(parameters) - len(free_parameters) - len(linked_parameters) > 0:
 
-            fixed_parameter_dict = collections.OrderedDict()
+            fixed_parameter_dict = dict()
 
             for parameter_name, parameter in list(parameters.items()):
 
@@ -805,7 +805,7 @@ class Model(Node):
                     this_name = long_path_formatter(parameter_name, 40)
 
                 d = parameter.to_dict()
-                fixed_parameter_dict[this_name] = collections.OrderedDict()
+                fixed_parameter_dict[this_name] = dict()
 
                 for key in ["value", "unit", "min_value", "max_value"]:
 
@@ -830,13 +830,13 @@ class Model(Node):
 
             for parameter_name, parameter in list(linked_parameters.items()):
 
-                parameter_dict = collections.OrderedDict()
+                parameter_dict = dict()
 
                 # Generate table with only a minimal set of info
 
                 variable, law = parameter.auxiliary_variable
 
-                this_dict = collections.OrderedDict()
+                this_dict = dict()
 
                 this_dict["linked to"] = variable.path
                 this_dict["function"] = law.name
@@ -860,7 +860,7 @@ class Model(Node):
         # Summary of free parameters
         if len(properties) > 0:
 
-            property_dict = collections.OrderedDict()
+            property_dict = dict()
 
             for property_name, prop in properties.items():
 
@@ -876,7 +876,7 @@ class Model(Node):
                     this_name = long_path_formatter(property_name, 40)
 
                 d = prop.to_dict()
-                property_dict[this_name] = collections.OrderedDict()
+                property_dict[this_name] = dict()
 
                 for key in ["value", "allowed values"]:
 
@@ -903,11 +903,11 @@ class Model(Node):
                 self._independent_variables.items()
             ):
 
-                v_dict = collections.OrderedDict()
+                v_dict = dict()
 
                 # Generate table with only a minimal set of info
 
-                this_dict = collections.OrderedDict()
+                this_dict = dict()
 
                 this_dict["current value"] = variable_instance.value
                 this_dict["unit"] = variable_instance.unit

--- a/astromodels/core/model.py
+++ b/astromodels/core/model.py
@@ -2,7 +2,6 @@ from builtins import zip
 
 __author__ = "giacomov"
 
-import collections
 import os
 import warnings
 from dataclasses import dataclass
@@ -456,9 +455,7 @@ class Model(Node):
         :return: dict()
         """
 
-        sources: Dict[str, Union[PointSource, ExtendedSource, ParticleSource]] = (
-            dict()
-        )
+        sources: Dict[str, Union[PointSource, ExtendedSource, ParticleSource]] = dict()
 
         for d in (
             self.point_sources,

--- a/astromodels/core/my_yaml.py
+++ b/astromodels/core/my_yaml.py
@@ -4,8 +4,6 @@ __author__ = "giacomov"
 # dictionaries instead of normal ones. This way the order in which things are expressed
 # in the file is maintained.
 
-import collections
-
 import yaml as my_yaml
 
 _mapping_tag = my_yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG

--- a/astromodels/core/my_yaml.py
+++ b/astromodels/core/my_yaml.py
@@ -16,8 +16,8 @@ def dict_representer(dumper, data):
 
 
 def dict_constructor(loader, node):
-    return collections.OrderedDict(loader.construct_pairs(node))
+    return dict(loader.construct_pairs(node))
 
 
-my_yaml.add_representer(collections.OrderedDict, dict_representer)
+my_yaml.add_representer(dict, dict_representer)
 my_yaml.add_constructor(_mapping_tag, dict_constructor)

--- a/astromodels/core/node_type.py
+++ b/astromodels/core/node_type.py
@@ -202,7 +202,7 @@ class NodeBase:
 
     def _recursively_gather_node_type(self, node, node_type) -> Dict[str, "NodeBase"]:
 
-        instances = collections.OrderedDict()
+        instances = dict()
 
         for child in node._get_children():
 
@@ -409,7 +409,7 @@ def _recurse_dict(d: Dict[str, Any], tree: Tree, branch_color: Optional[str] = N
 
     for k, v in d.items():
 
-        if isinstance(v, collections.OrderedDict):
+        if isinstance(v, dict):
 
             if branch_color is not None:
 

--- a/astromodels/core/node_type.py
+++ b/astromodels/core/node_type.py
@@ -1,4 +1,3 @@
-import collections
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, Type
 

--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -929,7 +929,7 @@ class ParameterBase(Node):
     def to_dict(self, minimal=False) -> Dict[str, Any]:
         """Returns the representation for serialization."""
 
-        data = collections.OrderedDict()
+        data = dict()
 
         if minimal:
 
@@ -1486,7 +1486,7 @@ class Parameter(ParameterBase):
 
                 data["value"] = "f(%s)" % self._aux_variable["variable"]._get_path()
 
-                aux_variable_law_data = collections.OrderedDict()
+                aux_variable_law_data = dict()
                 aux_variable_law_data[self._aux_variable["law"].name] = (
                     self._aux_variable["law"].to_dict()
                 )

--- a/astromodels/core/property.py
+++ b/astromodels/core/property.py
@@ -1,4 +1,3 @@
-import collections
 import copy
 from typing import Any, Dict, List, Optional
 

--- a/astromodels/core/property.py
+++ b/astromodels/core/property.py
@@ -166,7 +166,7 @@ class PropertyBase(Node):
     def to_dict(self, minimal=False) -> Dict[str, Any]:
         """Returns the representation for serialization."""
 
-        data = collections.OrderedDict()
+        data = dict()
 
         if minimal:
             # In the minimal representation we just output the value

--- a/astromodels/core/sky_direction.py
+++ b/astromodels/core/sky_direction.py
@@ -241,11 +241,11 @@ class SkyDirection(Node):
 
         if self._coord_type == "galactic":
 
-            return collections.OrderedDict((("l", self.l), ("b", self.b)))
+            return dict((("l", self.l), ("b", self.b)))
 
         else:
 
-            return collections.OrderedDict((("ra", self.ra), ("dec", self.dec)))
+            return dict((("ra", self.ra), ("dec", self.dec)))
 
     @property
     def equinox(self):
@@ -257,7 +257,7 @@ class SkyDirection(Node):
 
     def to_dict(self, minimal=False):
 
-        data = collections.OrderedDict()
+        data = dict()
 
         if self._coord_type == "equatorial":
 

--- a/astromodels/core/sky_direction.py
+++ b/astromodels/core/sky_direction.py
@@ -1,7 +1,5 @@
 __author__ = "giacomov"
 
-import collections
-
 from astropy import coordinates
 
 from astromodels.core.parameter import Parameter

--- a/astromodels/core/thread_safe_unit_format.py
+++ b/astromodels/core/thread_safe_unit_format.py
@@ -31,7 +31,7 @@ def _format_one(xxx_todo_changeme):
     # This is for example 'cm-2' if base=cm and power=-2,
     # but only 'cm' if base=cm and power=1
 
-    (base, power) = xxx_todo_changeme
+    base, power = xxx_todo_changeme
     return "%s%s" % (base.to_string(), power if power != 1 else "")
 
 

--- a/astromodels/core/tree.py
+++ b/astromodels/core/tree.py
@@ -1,4 +1,3 @@
-import collections
 from typing import Any, Dict
 
 from astromodels.core.node_type import NodeBase

--- a/astromodels/core/tree.py
+++ b/astromodels/core/tree.py
@@ -58,7 +58,7 @@ class Node(NodeBase):
 
     def to_dict(self, minimal: bool = False) -> Dict[str, Any]:
         """"""
-        this_dict: Dict[str, Any] = collections.OrderedDict()
+        this_dict: Dict[str, Any] = dict()
 
         for child in self._get_children():
 

--- a/astromodels/core/units.py
+++ b/astromodels/core/units.py
@@ -2,8 +2,6 @@ from builtins import object
 
 __author__ = "giacomov"
 
-import collections
-
 import astropy.units as u
 
 from astromodels.utils.pretty_list import dict_to_list

--- a/astromodels/core/units.py
+++ b/astromodels/core/units.py
@@ -71,7 +71,7 @@ class _AstromodelsUnits(object):
         if area_unit is None:
             area_unit = _AREA
 
-        self._units = collections.OrderedDict()
+        self._units = dict()
 
         self._units["energy"] = energy_unit
         self._units["time"] = time_unit

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -1,5 +1,4 @@
 import ast
-import collections
 import copy
 import inspect
 import math
@@ -853,9 +852,7 @@ class Function(Node):
 
         if properties is not None:
 
-            self._properties: Optional[Dict[str, FunctionProperty]] = (
-                dict()
-            )
+            self._properties: Optional[Dict[str, FunctionProperty]] = dict()
 
             for child_name, child in properties.items():
 

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -220,7 +220,7 @@ class FunctionMeta(type):
 
             # parse the properties
 
-            dct["_properties"] = collections.OrderedDict()
+            dct["_properties"] = dict()
 
             for property_name, property_definition in function_definition[
                 "properties"
@@ -250,7 +250,7 @@ class FunctionMeta(type):
         # below this dictionary will be used to create a copy of each parameter which
         # will be made available as child of the *instance*.
 
-        dct["_parameters"] = collections.OrderedDict()
+        dct["_parameters"] = dict()
 
         for parameter_name, parameter_definition in list(
             function_definition["parameters"].items()
@@ -334,7 +334,7 @@ class FunctionMeta(type):
 
         def info():
 
-            repr_dict = collections.OrderedDict()
+            repr_dict = dict()
 
             repr_dict["description"] = function_definition["description"]
 
@@ -342,7 +342,7 @@ class FunctionMeta(type):
                 repr_dict["formula"] = function_definition["latex"]
 
             # Add the description of each parameter and their current value
-            repr_dict["default parameters"] = collections.OrderedDict()
+            repr_dict["default parameters"] = dict()
 
             for parameter_name in list(dct["_parameters"].keys()):
 
@@ -353,7 +353,7 @@ class FunctionMeta(type):
             if dct["_properties"] is not None:
 
                 # Add the description of each parameter and their current value
-                repr_dict["default properties"] = collections.OrderedDict()
+                repr_dict["default properties"] = dict()
 
                 for property_name in list(dct["_properties"].keys()):
 
@@ -400,7 +400,7 @@ class FunctionMeta(type):
         # Create a copy of the parameters dictionary which is in the type,
         # otherwise every instance would share the same dictionary
 
-        copy_of_parameters = collections.OrderedDict()
+        copy_of_parameters = dict()
 
         # Fill it by duplicating the parameters contained in the dictionary in the type
 
@@ -420,7 +420,7 @@ class FunctionMeta(type):
 
         if type(instance)._properties is not None:
 
-            copy_of_properties = collections.OrderedDict()
+            copy_of_properties = dict()
 
             for key, value in type(instance)._properties.items():
 
@@ -839,7 +839,7 @@ class Function(Node):
         # might be different than the actual name of the parameter, use the .add_child
         # method instead of the add_children method
 
-        self._parameters: Dict[str, Parameter] = collections.OrderedDict()
+        self._parameters: Dict[str, Parameter] = dict()
 
         for child_name, child in list(parameters.items()):
 
@@ -854,7 +854,7 @@ class Function(Node):
         if properties is not None:
 
             self._properties: Optional[Dict[str, FunctionProperty]] = (
-                collections.OrderedDict()
+                dict()
             )
 
             for child_name, child in properties.items():
@@ -884,7 +884,7 @@ class Function(Node):
 
         # stores any extrernally linked functions
 
-        self._external_functions: Dict[str, "Function"] = collections.OrderedDict()
+        self._external_functions: Dict[str, "Function"] = dict()
 
     @property
     def n_dim(self) -> int:
@@ -900,7 +900,7 @@ class Function(Node):
         :return: dictionary of free parameters
         """
 
-        free_parameters = collections.OrderedDict(
+        free_parameters = dict(
             [(k, v) for k, v in list(self.parameters.items()) if v.free]
         )
 
@@ -1010,7 +1010,7 @@ class Function(Node):
 
             if self._external_functions:
 
-                data["external_functions"] = collections.OrderedDict()
+                data["external_functions"] = dict()
 
                 for k, v in self._external_functions.items():
 
@@ -1211,7 +1211,7 @@ class Function(Node):
 
     def _repr__base(self, rich_output):
 
-        repr_dict = collections.OrderedDict()
+        repr_dict = dict()
 
         repr_dict["description"] = self._function_definition["description"]
 
@@ -1220,7 +1220,7 @@ class Function(Node):
             repr_dict["formula"] = self._function_definition["latex"]
 
         # Add the description of each parameter and their current value
-        repr_dict["parameters"] = collections.OrderedDict()
+        repr_dict["parameters"] = dict()
 
         for parameter in self._get_children():
 
@@ -2057,11 +2057,11 @@ class CompositeFunction(Function):
         # Build the parameters dictionary assigning a new name to each parameter to
         # account for possible duplicates.
 
-        parameters = collections.OrderedDict()
+        parameters = dict()
 
-        properties = collections.OrderedDict()
+        properties = dict()
 
-        self._sub_children = collections.OrderedDict()
+        self._sub_children = dict()
 
         log.debug_node(f"we now have {len(self._functions)}")
 
@@ -2128,7 +2128,7 @@ class CompositeFunction(Function):
 
             # now, some functions may have children and we want to keep track of those
 
-            self._sub_children[function.name] = collections.OrderedDict()
+            self._sub_children[function.name] = dict()
 
             for child_name, child in function._children.items():
 
@@ -2325,11 +2325,11 @@ class CompositeFunction(Function):
 
             if flag:
 
-                data["external_functions"] = collections.OrderedDict()
+                data["external_functions"] = dict()
 
                 for i, function in enumerate(self._functions):
 
-                    this_function = collections.OrderedDict()
+                    this_function = dict()
 
                     for k, v in function.external_functions.items():
 
@@ -2370,7 +2370,7 @@ def get_function(function_name, composite_function_expression=None):
 
             function_class = _known_functions[function_name]
 
-            deferred_properites = collections.OrderedDict()
+            deferred_properites = dict()
 
             if function_class._properties is not None:
 
@@ -2493,7 +2493,7 @@ def list_functions():
 
     # Order by key (i.e., by function name)
 
-    ordered = collections.OrderedDict(sorted(functions_and_descriptions.items()))
+    ordered = dict(sorted(functions_and_descriptions.items()))
 
     # Format in a table
 
@@ -2569,7 +2569,7 @@ def _parse_function_expression(function_specification):
                 # let's see if there are any deferred
                 # properties
 
-                deferred_properites = collections.OrderedDict()
+                deferred_properites = dict()
 
                 if function_class._properties is not None:
 

--- a/astromodels/functions/template_model.py
+++ b/astromodels/functions/template_model.py
@@ -137,7 +137,7 @@ class TemplateModelFactory(object):
         # We create a dictionary which will contain the grid for each parameter
 
         self._parameters_grids: Dict[str, Optional[np.ndarray]] = (
-            collections.OrderedDict()
+            dict()
         )
 
         for parameter_name in names_of_parameters:
@@ -456,7 +456,7 @@ class TemplateFile:
 
             grid = f["grid"][()]
 
-            parameters = collections.OrderedDict()
+            parameters = dict()
 
             for k in parameter_order:
                 parameters[k] = f["parameters"][k][()]
@@ -546,7 +546,7 @@ class TemplateModel(Function1D, metaclass=FunctionMeta):
         except Exception:
             raise InvalidTemplateModelFile()
 
-        self._parameters_grids = collections.OrderedDict()
+        self._parameters_grids = dict()
 
         for key in template_file.parameter_order:
             try:
@@ -578,7 +578,7 @@ class TemplateModel(Function1D, metaclass=FunctionMeta):
 
         # Make the dictionary of parameters
 
-        function_definition = collections.OrderedDict()
+        function_definition = dict()
 
         function_definition["description"] = description
 
@@ -586,7 +586,7 @@ class TemplateModel(Function1D, metaclass=FunctionMeta):
 
         # Now build the parameters according to the content of the parameter grid
 
-        parameters = collections.OrderedDict()
+        parameters = dict()
 
         parameters["K"] = Parameter("K", 1.0)
         parameters["scale"] = Parameter("scale", 1.0)
@@ -962,7 +962,7 @@ def convert_old_table_model(model_name: str):
     with HDFStore(filename_sanitized) as store:
         data_frame = store["data_frame"]
 
-        parameters_grids = collections.OrderedDict()
+        parameters_grids = dict()
 
         processed_parameters = 0
 
@@ -1014,7 +1014,7 @@ def convert_old_table_model(model_name: str):
 
         # Make the dictionary of parameters
 
-        function_definition = collections.OrderedDict()
+        function_definition = dict()
 
         function_definition["description"] = description
 

--- a/astromodels/functions/template_model.py
+++ b/astromodels/functions/template_model.py
@@ -1,4 +1,3 @@
-import collections
 import gc
 import os
 import re
@@ -136,9 +135,7 @@ class TemplateModelFactory(object):
 
         # We create a dictionary which will contain the grid for each parameter
 
-        self._parameters_grids: Dict[str, Optional[np.ndarray]] = (
-            dict()
-        )
+        self._parameters_grids: Dict[str, Optional[np.ndarray]] = dict()
 
         for parameter_name in names_of_parameters:
             self._parameters_grids[parameter_name] = None

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -294,7 +294,7 @@ class ExtendedSource(Source, Node):
 
         :return:
         """
-        free_parameters = collections.OrderedDict()
+        free_parameters = dict()
 
         for component in list(self._components.values()):
 
@@ -320,7 +320,7 @@ class ExtendedSource(Source, Node):
 
         :return:
         """
-        all_parameters = collections.OrderedDict()
+        all_parameters = dict()
 
         for component in list(self._components.values()):
 
@@ -343,13 +343,13 @@ class ExtendedSource(Source, Node):
 
         # Make a dictionary which will then be transformed in a list
 
-        repr_dict = collections.OrderedDict()
+        repr_dict = dict()
 
         key = "%s (extended source)" % self.name
 
-        repr_dict[key] = collections.OrderedDict()
+        repr_dict[key] = dict()
         repr_dict[key]["shape"] = self._spatial_shape.to_dict(minimal=True)
-        repr_dict[key]["spectrum"] = collections.OrderedDict()
+        repr_dict[key]["spectrum"] = dict()
 
         for component_name, component in list(self.components.items()):
             repr_dict[key]["spectrum"][component_name] = component.to_dict(minimal=True)

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -1,5 +1,3 @@
-import collections
-
 import astropy.units as u
 import numpy as np
 

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -87,12 +87,12 @@ class ParticleSource(Source, Node):
 
         # Make a dictionary which will then be transformed in a list
 
-        repr_dict = collections.OrderedDict()
+        repr_dict = dict()
 
         key = "%s (particle source)" % self.name
 
-        repr_dict[key] = collections.OrderedDict()
-        repr_dict[key]["spectrum"] = collections.OrderedDict()
+        repr_dict[key] = dict()
+        repr_dict[key]["spectrum"] = dict()
 
         for component_name, component in list(self.components.items()):
 
@@ -108,7 +108,7 @@ class ParticleSource(Source, Node):
 
         :return:
         """
-        free_parameters = collections.OrderedDict()
+        free_parameters = dict()
 
         for component in self._components.values():
 
@@ -128,7 +128,7 @@ class ParticleSource(Source, Node):
 
         :return:
         """
-        all_parameters = collections.OrderedDict()
+        all_parameters = dict()
 
         for component in self._components.values():
 

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -1,6 +1,5 @@
 __author__ = "giacomov"
 
-import collections
 
 import numpy
 

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -1,4 +1,3 @@
-import collections
 from typing import Dict, Optional
 
 import astropy.units as u

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -295,7 +295,7 @@ class PointSource(Source, Node):
 
         :return:
         """
-        free_parameters = collections.OrderedDict()
+        free_parameters = dict()
 
         for component in list(self._components.values()):
 
@@ -321,7 +321,7 @@ class PointSource(Source, Node):
 
         :return:
         """
-        all_parameters = collections.OrderedDict()
+        all_parameters = dict()
 
         for component in self._components.values():
 
@@ -344,13 +344,13 @@ class PointSource(Source, Node):
 
         # Make a dictionary which will then be transformed in a list
 
-        repr_dict = collections.OrderedDict()
+        repr_dict = dict()
 
         key = "%s (point source)" % self.name
 
-        repr_dict[key] = collections.OrderedDict()
+        repr_dict[key] = dict()
         repr_dict[key]["position"] = self._sky_position.to_dict(minimal=True)
-        repr_dict[key]["spectrum"] = collections.OrderedDict()
+        repr_dict[key]["spectrum"] = dict()
 
         for component_name, component in list(self.components.items()):
 

--- a/astromodels/sources/source.py
+++ b/astromodels/sources/source.py
@@ -30,7 +30,7 @@ class Source(object):
     ):
 
         # Make the dictionary of components
-        self._components: Dict[str, Any] = collections.OrderedDict()
+        self._components: Dict[str, Any] = dict()
 
         for component in list_of_components:
 

--- a/astromodels/sources/source.py
+++ b/astromodels/sources/source.py
@@ -1,6 +1,5 @@
 __author__ = "giacomov"
 
-import collections
 from enum import Enum, unique
 from typing import Any, Dict, List
 

--- a/astromodels/tests/test_extended_source.py
+++ b/astromodels/tests/test_extended_source.py
@@ -158,7 +158,8 @@ def test_call():
         if name == "SpatialTemplate_2D_Healpix":
             if not has_mhealpy:
                 pytest.skip(
-                    "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
+                    "Skipping SpatialTemplate_2D_Healpix test because "
+                    "mhealpy is missing"
                 )
             make_test_healpix_template("__test.fits")
             shape = class_type(fits_file="__test.fits")
@@ -256,7 +257,8 @@ def test_call_with_units():
         if name == "SpatialTemplate_2D_Healpix":
             if not has_mhealpy:
                 pytest.skip(
-                    "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
+                    "Skipping SpatialTemplate_2D_Healpix test because "
+                    "mhealpy is missing"
                 )
             make_test_healpix_template("__test.fits")
 

--- a/astromodels/tests/test_extended_source.py
+++ b/astromodels/tests/test_extended_source.py
@@ -158,7 +158,7 @@ def test_call():
         if name == "SpatialTemplate_2D_Healpix":
             if not has_mhealpy:
                 pytest.skip(
-                  "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
+                    "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
                 )
             make_test_healpix_template("__test.fits")
             shape = class_type(fits_file="__test.fits")
@@ -256,7 +256,7 @@ def test_call_with_units():
         if name == "SpatialTemplate_2D_Healpix":
             if not has_mhealpy:
                 pytest.skip(
-                  "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
+                    "Skipping SpatialTemplate_2D_Healpix test because mhealpy is missing"
                 )
             make_test_healpix_template("__test.fits")
 

--- a/astromodels/tests/test_load_xspec_models.py
+++ b/astromodels/tests/test_load_xspec_models.py
@@ -81,7 +81,7 @@ def test_find_model_dat():
 @skip_if_xspec_is_not_available
 def test_get_models():
     model_definitions = get_models(find_model_dat())
-    assert isinstance(model_definitions, collections.OrderedDict)
+    assert isinstance(model_definitions, dict)
 
     # the gaussian line should be available in all versions supported
     assert (

--- a/astromodels/tests/test_load_xspec_models.py
+++ b/astromodels/tests/test_load_xspec_models.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import os
-import collections
 import logging
 
 import astropy.units as u

--- a/astromodels/tests/test_xspec_settings.py
+++ b/astromodels/tests/test_xspec_settings.py
@@ -6,6 +6,7 @@ if find_spec("xspec") is None:
     has_XSPEC = False
 else:
     from astromodels.xspec.xspec_settings import xspec_abund, xspec_cosmo, xspec_xsect
+
     has_XSPEC = True
 
 
@@ -42,6 +43,7 @@ def test_xspec_xsect():
 @skip_if_xspec_is_not_available
 def test_xspec_model_import():
     from astromodels.xspec import XS_bbody, XS_phabs, XS_powerlaw
+
     assert XS_bbody is not None
     assert XS_phabs is not None
     assert XS_powerlaw is not None

--- a/astromodels/xspec/factory.py
+++ b/astromodels/xspec/factory.py
@@ -1,4 +1,3 @@
-import collections
 import os
 import re
 import sys

--- a/astromodels/xspec/factory.py
+++ b/astromodels/xspec/factory.py
@@ -171,7 +171,7 @@ def get_models(model_dat_path):
 
     lines = model_dat.split("\n")
 
-    model_definitions = collections.OrderedDict()
+    model_definitions = dict()
 
     for line in lines:
 
@@ -208,14 +208,14 @@ def get_models(model_dat_path):
                     flag_2,
                 ) = line.split()
 
-            this_model = collections.OrderedDict()
+            this_model = dict()
 
             this_model["description"] = (
                 "The %s model from XSpec (https://heasarc.gsfc.nasa.gov/xanadu/"
                 "xspec/manual/XspecModels.html)" % model_name
             )
 
-            this_model["parameters"] = collections.OrderedDict()
+            this_model["parameters"] = dict()
 
             model_definitions[(model_name, library_function, model_type)] = this_model
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,6 @@ import os
 import sys
 from pathlib import Path
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -78,7 +77,9 @@ def run_apidoc(app):
                 "Accept": "application/vnd.github.v3+json",
             }
             # Get PR details to find the Head SHA
-            pr_url = f"https://api.github.com/repos/threeML/astromodels/pulls/{pr_number}"
+            pr_url = (
+                f"https://api.github.com/repos/threeML/astromodels/pulls/{pr_number}"
+            )
             pr_res = requests.get(pr_url, headers=headers, timeout=10)
 
             if pr_res.status_code == 200:
@@ -184,6 +185,7 @@ def run_apidoc(app):
         raise RuntimeError(
             "Failed to generate API stubs locally using sphinx-apidoc. Aborting build."
         )
+
 
 # -- General configuration ---------------------------------------------------
 
@@ -305,4 +307,4 @@ print("Done.")
 
 
 def setup(app):
-   app.connect("builder-inited", run_apidoc)
+    app.connect("builder-inited", run_apidoc)

--- a/versioneer.py
+++ b/versioneer.py
@@ -300,6 +300,7 @@ https://img.shields.io/travis/com/python-versioneer/python-versioneer.svg
 [travis-url]: https://travis-ci.com/github/python-versioneer/python-versioneer
 
 """
+
 # pylint:disable=invalid-name,import-outside-toplevel,missing-function-docstring
 # pylint:disable=missing-class-docstring,too-many-branches,too-many-statements
 # pylint:disable=raise-missing-from,too-many-lines,too-many-locals,import-error
@@ -512,9 +513,7 @@ def run_command(
     return stdout, process.returncode
 
 
-LONG_VERSION_PY[
-    "git"
-] = r'''
+LONG_VERSION_PY["git"] = r'''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build


### PR DESCRIPTION
## Motivation
Since [Python 3.6](https://docs.python.org/3/whatsnew/3.6.html#new-dict-implementation) the ordering of `keys` in a `dict` is guaranteed to be kept.

For our use cases it should suffice to use `dict` instead of `collections.OrderedDict` which should also result in a _slight_ performance increase

## Implementation
Simply replaced every occurrence of `OrderedDict` by `dict`


<!-- readthedocs-preview astromodels start -->
----
📚 Documentation preview 📚: https://astromodels--262.org.readthedocs.build/en/262/

<!-- readthedocs-preview astromodels end -->