### PR TITLE
Suggestion for codecov settings

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,17 +1,19 @@
 #
-# This codecov.yml is the default configuration for
-# all repositories on Codecov. You may adjust the settings
-# below in your own codecov.yml in your repository.
-#
 coverage:
   precision: 2
   round: down
   range: 70..100
 
   status:
-    # Learn more at https://codecov.io/docs#yaml_default_commit_status
-    project: true
-    patch: true
+    project:
+      default:
+        target: auto
+        threshold: 5 # allow drops by 5 percent
+        if_ci_failed: error
+    patch:
+      default:
+        target: auto
+        threshold: 0
     changes: false
 
 ignore:
@@ -21,6 +23,5 @@ ignore:
   - "astromodels/functions/numba_functions.py" # cannot cover jitted code
 
 comment:
-  layout: "header, diff"
-  behavior: default
-
+    layout: "condensed_header, condensed_files, condensed_footer"
+    behavior: default


### PR DESCRIPTION
Following up on @israelmcmc 's remarks in slack on the codecov settings - a more "forgiving" setup

@israelmcmc and @ndilalla please feel free to change or comment as you please - this is just a suggestion :)

This config should: 
- keep total coverage between 70-100%
- allow the total coverage to drop by up to 5% for a single PR but has to be >70%
- patch coverage has to be 100% (might be a bit to strict)
- added the newest defaults for the comments from codecov

<!-- readthedocs-preview astromodels start -->
----
📚 Documentation preview 📚: https://astromodels--263.org.readthedocs.build/en/263/

<!-- readthedocs-preview astromodels end -->