### PR TITLE
280 standardize access to spectrum normalization parameters

### DIFF
--- a/astromodels/functions/functions_1D/absorption.py
+++ b/astromodels/functions/functions_1D/absorption.py
@@ -231,7 +231,7 @@ class TbAbs(Function1D, metaclass=FunctionMeta):
         NH :
             desc : absorbing column density in units of 1e22 particles per cm^2
             initial value : 1.0
-            is_normalization : True
+            is_normalization : False
             transformation : log10
             min : 1e-4
             max : 1e4
@@ -325,7 +325,7 @@ class WAbs(Function1D, metaclass=FunctionMeta):
         NH :
             desc : absorbing column density in units of 1e22 particles per cm^2
             initial value : 1.0
-            is_normalization : True
+            is_normalization : False
             transformation : log10
             min : 1e-4
             max : 1e4

--- a/astromodels/functions/functions_2D.py
+++ b/astromodels/functions/functions_2D.py
@@ -31,6 +31,7 @@ class Latitude_galactic_diffuse(Function2D, metaclass=FunctionMeta):
 
             desc : normalization
             initial value : 1
+            is_normalization : True
 
         sigma_b :
 
@@ -675,6 +676,8 @@ class SpatialTemplate_2D(Function2D, metaclass=FunctionMeta):
             desc : normalization
             initial value : 1
             fix : yes
+            is_normalization : True
+
         hash :
 
             desc: hash of model map [needed for memoization]
@@ -860,6 +863,8 @@ class SpatialTemplate_2D_Healpix(Function2D, metaclass=FunctionMeta):
             desc : normalization
             initial value : 1
             fix : yes
+            is_normalization : True
+
         hash :
             desc: hash of model map
             initial value: 1

--- a/astromodels/functions/functions_3D.py
+++ b/astromodels/functions/functions_3D.py
@@ -684,6 +684,7 @@ class GalPropTemplate_3D(Function3D):
             desc : normalization
             initial value : 1
             fix : yes
+            is_normalization : True
 
         hash :
 
@@ -894,6 +895,7 @@ class Hermes(Function3D, metaclass=FunctionMeta):
             desc : normalization scale factor
             initial value : 1
             fix : yes
+            is_normalization : True
 
         hash :
 

--- a/astromodels/xspec/factory.py
+++ b/astromodels/xspec/factory.py
@@ -717,6 +717,7 @@ def generate_xs_model_file(
             "delta": 0.1,
             "unit": "keV / (cm2 s)",
             "free": True,
+            "is_normalization": True,
         }
 
     assert model_type != "con", "Convolution models are not yet supported"


### PR DESCRIPTION
This resolves #280 
Adds missing `is_normalization` properties of parameters 
Fixes two instances in astromodels/functions/functions_1D/absorption.py where the flag was wrong in my opinon

<!-- readthedocs-preview astromodels start -->
----
📚 Documentation preview 📚: https://astromodels--281.org.readthedocs.build/en/281/

<!-- readthedocs-preview astromodels end -->