### PR TITLE
Stop using Numba to implement 1D functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 
 ## v2.6
-### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-06-26)
+### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-07-31)
 
 [Full Changelog](https://github.com/threeML/astromodels/compare/v2.5.1...v2.6.0)
+
+**Implemented enhancements:**
+
+- Use builtin dicts instead of OrderedDicts [\#262](https://github.com/threeML/astromodels/pull/262) ([PreisTo](https://github.com/PreisTo))
 
 **Closed issues:**
 
@@ -13,6 +17,27 @@
 - ThreadSafe error with latest astromodels dev [\#243](https://github.com/threeML/astromodels/issues/243)
 - SpatialTemplate\_2D, ExtendedSource and default units [\#238](https://github.com/threeML/astromodels/issues/238)
 - Error Importing Astromodels with python 3.11.3 [\#201](https://github.com/threeML/astromodels/issues/201)
+
+**Merged pull requests:**
+
+- Fix custom startup\_warnings setup in user configs [\#282](https://github.com/threeML/astromodels/pull/282) ([PreisTo](https://github.com/PreisTo))
+- Dev [\#279](https://github.com/threeML/astromodels/pull/279) ([ndilalla](https://github.com/ndilalla))
+- Fix requiring two numpy versions conda [\#278](https://github.com/threeML/astromodels/pull/278) ([PreisTo](https://github.com/PreisTo))
+- Add Polarizaton Transformation [\#275](https://github.com/threeML/astromodels/pull/275) ([PreisTo](https://github.com/PreisTo))
+- Update build dependencies [\#274](https://github.com/threeML/astromodels/pull/274) ([PreisTo](https://github.com/PreisTo))
+- Fix failing conda CIs + move from boa to rattler-build [\#273](https://github.com/threeML/astromodels/pull/273) ([PreisTo](https://github.com/PreisTo))
+- Multicore setup for pytest [\#268](https://github.com/threeML/astromodels/pull/268) ([PreisTo](https://github.com/PreisTo))
+- Implement template-fitting class [\#267](https://github.com/threeML/astromodels/pull/267) ([torresramiro350](https://github.com/torresramiro350))
+- Support calling PointSource without \_\_len\_\_ [\#266](https://github.com/threeML/astromodels/pull/266) ([PreisTo](https://github.com/PreisTo))
+- Stokes Polarization from floats [\#265](https://github.com/threeML/astromodels/pull/265) ([PreisTo](https://github.com/PreisTo))
+- Suggestion for codecov settings [\#263](https://github.com/threeML/astromodels/pull/263) ([PreisTo](https://github.com/PreisTo))
+- Remove unused dependencies + fix conda withouth xspec [\#261](https://github.com/threeML/astromodels/pull/261) ([PreisTo](https://github.com/PreisTo))
+- Use logging.getLogger\(\_\_name\_\_\) instead of setup\_logger [\#260](https://github.com/threeML/astromodels/pull/260) ([israelmcmc](https://github.com/israelmcmc))
+- Add integrate\(\) function [\#257](https://github.com/threeML/astromodels/pull/257) ([PreisTo](https://github.com/PreisTo))
+- New docs changes [\#255](https://github.com/threeML/astromodels/pull/255) ([ndilalla](https://github.com/ndilalla))
+- Build mutliple versions for conda using variants [\#252](https://github.com/threeML/astromodels/pull/252) ([PreisTo](https://github.com/PreisTo))
+- Unpolarized class as default polarization [\#249](https://github.com/threeML/astromodels/pull/249) ([PreisTo](https://github.com/PreisTo))
+- Validate CAR coordinates and adjust area calculation [\#247](https://github.com/threeML/astromodels/pull/247) ([GallegoSav](https://github.com/GallegoSav))
 
 
 ## v2.5
@@ -536,7 +561,6 @@
 - adding additoonal search paths for gfortran because: OS X [\#14](https://github.com/threeML/astromodels/pull/14) ([grburgess](https://github.com/grburgess))
 - Fixed function3D [\#13](https://github.com/threeML/astromodels/pull/13) ([zhoouhaoo](https://github.com/zhoouhaoo))
 - Adding models [\#12](https://github.com/threeML/astromodels/pull/12) ([grburgess](https://github.com/grburgess))
-- New XSPEC uses '.' to separate versions. Added checks for this [\#6](https://github.com/threeML/astromodels/pull/6) ([grburgess](https://github.com/grburgess))
 - added OSX lib lookup [\#4](https://github.com/threeML/astromodels/pull/4) ([grburgess](https://github.com/grburgess))
 
 

--- a/astromodels/functions/core_functions.py
+++ b/astromodels/functions/core_functions.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def plaw_eval(x, K, index, piv):
 
     return K * np.pow(x / piv, index)
@@ -45,7 +46,7 @@ def band_eval(x, K, alpha, beta, E0, piv):
 
     factor_ab = np.exp(beta - alpha) * np.pow(break_point / piv, alpha - beta)
 
-    lo_mask = (x < break_point)
+    lo_mask = x < break_point
 
     xlo = x[lo_mask]
     out[lo_mask] = K * np.pow(xlo / piv, alpha) * np.exp(-xlo / E0)
@@ -62,10 +63,10 @@ def bplaw_eval(x, K, xb, alpha, beta, piv):
 
     factor = np.pow(xb / piv, alpha - beta)
 
-    lo_mask = (x < xb)
+    lo_mask = x < xb
 
     xlo = x[lo_mask]
-    out[lo_mask] =  K * np.pow(xlo / piv, alpha)
+    out[lo_mask] = K * np.pow(xlo / piv, alpha)
 
     xhi = x[~lo_mask]
     out[~lo_mask] = K * factor * np.pow(xhi / piv, beta)
@@ -74,6 +75,7 @@ def bplaw_eval(x, K, xb, alpha, beta, piv):
 
 
 LN2 = np.log(2.0)
+
 
 def sbplaw_eval(x, K, alpha, be, bs, beta, piv):
 
@@ -156,7 +158,7 @@ def dbl_sbpl(x, K, a1, a2, b1, xp, xb, n1, n2, xpiv):
 
 def plaw_integral(a, b, K, i, piv):
     if i != -1:
-        M = K * piv / (i+1)
+        M = K * piv / (i + 1)
         return M * ((b / piv) ** (i + 1) - (a / piv) ** (i + 1))
     else:
         M = K * piv

--- a/astromodels/functions/core_functions.py
+++ b/astromodels/functions/core_functions.py
@@ -1,0 +1,163 @@
+import numpy as np
+
+def plaw_eval(x, K, index, piv):
+
+    return K * np.pow(x / piv, index)
+
+
+def plaw_flux_norm(index, a, b):
+    """Energy flux power law."""
+
+    if index != -2:
+        dp2 = 2 + index
+        intflux = (np.pow(b, dp2) - np.pow(a, dp2)) / dp2
+    else:
+        intflux = -np.log(a / b)
+
+    return intflux
+
+
+def cplaw_eval(x, K, xc, index, piv):
+
+    # Compute it in logarithm to avoid roundoff errors, then raise it
+    log_v = index * np.log(x / piv) - (x / xc)
+    return K * np.exp(log_v)
+
+
+def cplaw_inverse_eval(x, K, b, index, piv):
+
+    # Compute it in logarithm to avoid roundoff errors, then raise it
+    log_v = index * np.log(x / piv) - x * b
+    return K * np.exp(log_v)
+
+
+def super_cplaw_eval(x, K, piv, index, xc, gamma):
+
+    log_v = index * np.log(x / piv) - np.pow(x / xc, gamma)
+    return K * np.exp(log_v)
+
+
+def band_eval(x, K, alpha, beta, E0, piv):
+
+    out = np.empty_like(x)
+
+    break_point = (alpha - beta) * E0
+
+    factor_ab = np.exp(beta - alpha) * np.pow(break_point / piv, alpha - beta)
+
+    lo_mask = (x < break_point)
+
+    xlo = x[lo_mask]
+    out[lo_mask] = K * np.pow(xlo / piv, alpha) * np.exp(-xlo / E0)
+
+    xhi = x[~lo_mask]
+    out[~lo_mask] = K * factor_ab * np.pow(xhi / piv, beta)
+
+    return out
+
+
+def bplaw_eval(x, K, xb, alpha, beta, piv):
+
+    out = np.empty_like(x)
+
+    factor = np.pow(xb / piv, alpha - beta)
+
+    lo_mask = (x < xb)
+
+    xlo = x[lo_mask]
+    out[lo_mask] =  K * np.pow(xlo / piv, alpha)
+
+    xhi = x[~lo_mask]
+    out[~lo_mask] = K * factor * np.pow(xhi / piv, beta)
+
+    return out
+
+
+LN2 = np.log(2.0)
+
+def sbplaw_eval(x, K, alpha, be, bs, beta, piv):
+
+    def log_cosh(x):
+        """
+        An overflow-resistant computation of
+        log(0.5 * (exp(x) + exp(-x)))
+        """
+        absx = np.abs(x)
+        return absx + np.log1p(np.exp(-2 * absx)) - LN2
+
+    B = 0.5 * (alpha + beta)
+    M = 0.5 * (beta - alpha)
+
+    Mbs = M * bs
+
+    # previously, the log1p/exp contribution to log_cosh was
+    # ignored for arg < -6 or > +4; this introduced deviation of
+    # up to ~1e-4 vs log_cosh.
+
+    arg_piv = np.log10(piv / be) / bs
+    pcosh_piv = log_cosh(arg_piv)
+
+    arg = np.log10(x / be) / bs
+    pcosh = log_cosh(arg)
+
+    return K * np.pow(x / piv, B) * np.pow(10.0, Mbs * (pcosh - pcosh_piv))
+
+
+def bb_eval(x, K, kT):
+
+    return K * x * x / np.expm1(x / kT)
+
+
+def mbb_eval(x, K, kT):
+
+    arg = x / kT
+    exp_arg = np.exp(-arg)
+
+    out = np.pow(arg, 1.5) * exp_arg / np.sqrt(1 - exp_arg)
+    return K * out / x
+
+
+def ggrb_int_pl(a, b, Ec, Emin, Emax):
+
+    pre = np.pow(a - b, a - b) * np.exp(b - a) / np.pow(Ec, b)
+
+    if b != -2:
+        b2 = 2 + b
+        return pre / b2 * (np.pow(Emax, b2) - np.pow(Emin, b2))
+    else:
+        return pre * np.log(Emax / Emin)
+
+
+def non_diss_photoshere_generic(x, K, ec, piv, a, b):
+
+    log_v = a * np.log(x / piv) - np.pow(x / ec, b)
+    return K * np.exp(log_v)
+
+
+def dbl_sbpl(x, K, a1, a2, b1, xp, xb, n1, n2, xpiv):
+
+    xj = xp * np.pow(-(a2 + 2) / (b1 + 2), 1.0 / ((b1 - a2) * n2))
+
+    arg1 = xj / xb
+    arg2 = x / xb
+    arg3 = x / xj
+
+    inner1 = np.pow(arg2, -a1 * n1) + np.pow(arg2, -a2 * n1)
+
+    inner2 = np.pow(arg1, -a1 * n1) + np.pow(arg1, -a2 * n1)
+
+    out = np.pow(xb / xpiv, a1) * np.pow(
+        np.pow(inner1, n2 / n1) + np.pow(arg3, -b1 * n2) * np.pow(inner2, n2 / n1),
+        -1 / n2,
+    )
+
+    return K * out
+
+
+def plaw_integral(a, b, K, i, piv):
+    if i != -1:
+        M = K * piv / (i+1)
+        return M * ((b / piv) ** (i + 1) - (a / piv) ** (i + 1))
+    else:
+        M = K * piv
+        return M * (np.log(b / piv) - np.log(a / piv))

--- a/astromodels/functions/functions_1D/blackbody.py
+++ b/astromodels/functions/functions_1D/blackbody.py
@@ -1,6 +1,6 @@
 import astropy.units as astropy_units
 
-import astromodels.functions.numba_functions as nb_func
+import astromodels.functions.core_functions as nb_func
 from astromodels.functions.function import (
     Function1D,
     FunctionMeta,

--- a/astromodels/functions/functions_1D/powerlaws.py
+++ b/astromodels/functions/functions_1D/powerlaws.py
@@ -4,7 +4,7 @@ import astropy.units as astropy_units
 import numpy as np
 from scipy.special import gamma, gammaincc
 
-import astromodels.functions.numba_functions as nb_func
+import astromodels.functions.core_functions as nb_func
 from astromodels.functions.function import (
     Function1D,
     FunctionMeta,


### PR DESCRIPTION
Following a discussion on the cosipy Slack, I put together the following quick test to evaluate whether Numba accelerates 1D function evaluation in Astromodels.  

In this branch, I replaced all the Numba functions in numba_functions.py with new, pure Numpy implementations in core_functions.py.  The Numpy implementations consistently use Numpy rather than Python's math library and remove any explicit loops that were added for Numba acceleration.  In a couple of cases (Band and broken powerlaw), I used Numpy masking to replace an unavoidable branch on the argument value for vector inputs.

These functions all pass Astropy's test suite, which checks for agreement with stored values to within single precision, except for SmoothlyBrokenPowerLaw.  For that function, the Numba version switches to an asymptotic formula for x < -6 or x > 4, which introduces a relative error of about 1e-6 vs the non-asymptotic case.  I used an overflow-safe implementation that avoids the need for the asymptotic case, so I believe my version is actually more accurate.  For other functions, agreement is much better than single-precision -- more like 1 part in 10^-14 or better.

To assess the performance impact of this change, I ran each 1D function from powerlaws.py and blackbody.py (the ones that use the Numba implementations) for 1000 iterations with its default parameters on an input x consisting of 1 million random values between 0 and 1.  Times were measured after an initial 5-iteration warmup to ensure that I did not measure LLVM or other 1-time overhead for the Numba functions.  Here are my results on a 2.3 GHz Intel(R) Xeon(R) Gold 5118 CPU running Linux, using a fresh Conda environment for Astromodels with the latest dependencies as of 8/16/2026:

<img width="752" height="452" alt="image" src="https://github.com/user-attachments/assets/957d6885-0359-4440-a0cc-d213a7e00b0d" />

For all functions except Blackbody and ModifiedBlackbody, the pure Numpy implementation was faster -- occasionally several times faster.

Some thoughts on why we see these results... in the absence of parallelization (which is not done in Astromodels right now), Numba achieves its speedup by (1) eliminating interpreter overhead, (2) implementing basic compiler optimizations like common subexpression elimination, and (3) using looping to fuse multi-step operations and avoid creating intermediate arrays.  The third of these happens only if the user codes it that way; some of the Numba functions in Astromodels, such as the cutoff powerlaw implementation, do this, but not all do.

If a Numba implementation does nothing except call Numpy vectorized operations, as in plaw_eval(), it will likely see no benefit and will pay overhead associated with things like calling convention setup.  Functions that implement explicit loops over complex operations, like cplaw_eval(), *should* benefit from eliminating intermediate memory allocations.  Unfortunately, on x86, Numba is known to use slower versions of the basic transcendental functions than the Numpy library. Consequently, the expected performance gain is canceled out by these slower functions.  (I've seen the same phenomenon with the numexpr package.)

It's also worth noting that I measured performance for a large input x, where the cost of operations likely dominates Numpy allocation and interpreter overhead.  Some of these functions might be faster in Numba for much smaller x.  But that's probably not the most important case for overall application performance.

Note for future: I suspect the use of Numba in absorption.py could similarly be removed with no ill consequences, but I didn't have a test case for this readily to hand.  The uses in extinction.py are better candidates for Numba being faster.