### PR TITLE
Simplify source classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 
 ## v2.6
-### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-06-26)
+### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-07-31)
 
 [Full Changelog](https://github.com/threeML/astromodels/compare/v2.5.1...v2.6.0)
+
+**Implemented enhancements:**
+
+- Use builtin dicts instead of OrderedDicts [\#262](https://github.com/threeML/astromodels/pull/262) ([PreisTo](https://github.com/PreisTo))
 
 **Closed issues:**
 
@@ -13,6 +17,27 @@
 - ThreadSafe error with latest astromodels dev [\#243](https://github.com/threeML/astromodels/issues/243)
 - SpatialTemplate\_2D, ExtendedSource and default units [\#238](https://github.com/threeML/astromodels/issues/238)
 - Error Importing Astromodels with python 3.11.3 [\#201](https://github.com/threeML/astromodels/issues/201)
+
+**Merged pull requests:**
+
+- Fix custom startup\_warnings setup in user configs [\#282](https://github.com/threeML/astromodels/pull/282) ([PreisTo](https://github.com/PreisTo))
+- Dev [\#279](https://github.com/threeML/astromodels/pull/279) ([ndilalla](https://github.com/ndilalla))
+- Fix requiring two numpy versions conda [\#278](https://github.com/threeML/astromodels/pull/278) ([PreisTo](https://github.com/PreisTo))
+- Add Polarizaton Transformation [\#275](https://github.com/threeML/astromodels/pull/275) ([PreisTo](https://github.com/PreisTo))
+- Update build dependencies [\#274](https://github.com/threeML/astromodels/pull/274) ([PreisTo](https://github.com/PreisTo))
+- Fix failing conda CIs + move from boa to rattler-build [\#273](https://github.com/threeML/astromodels/pull/273) ([PreisTo](https://github.com/PreisTo))
+- Multicore setup for pytest [\#268](https://github.com/threeML/astromodels/pull/268) ([PreisTo](https://github.com/PreisTo))
+- Implement template-fitting class [\#267](https://github.com/threeML/astromodels/pull/267) ([torresramiro350](https://github.com/torresramiro350))
+- Support calling PointSource without \_\_len\_\_ [\#266](https://github.com/threeML/astromodels/pull/266) ([PreisTo](https://github.com/PreisTo))
+- Stokes Polarization from floats [\#265](https://github.com/threeML/astromodels/pull/265) ([PreisTo](https://github.com/PreisTo))
+- Suggestion for codecov settings [\#263](https://github.com/threeML/astromodels/pull/263) ([PreisTo](https://github.com/PreisTo))
+- Remove unused dependencies + fix conda withouth xspec [\#261](https://github.com/threeML/astromodels/pull/261) ([PreisTo](https://github.com/PreisTo))
+- Use logging.getLogger\(\_\_name\_\_\) instead of setup\_logger [\#260](https://github.com/threeML/astromodels/pull/260) ([israelmcmc](https://github.com/israelmcmc))
+- Add integrate\(\) function [\#257](https://github.com/threeML/astromodels/pull/257) ([PreisTo](https://github.com/PreisTo))
+- New docs changes [\#255](https://github.com/threeML/astromodels/pull/255) ([ndilalla](https://github.com/ndilalla))
+- Build mutliple versions for conda using variants [\#252](https://github.com/threeML/astromodels/pull/252) ([PreisTo](https://github.com/PreisTo))
+- Unpolarized class as default polarization [\#249](https://github.com/threeML/astromodels/pull/249) ([PreisTo](https://github.com/PreisTo))
+- Validate CAR coordinates and adjust area calculation [\#247](https://github.com/threeML/astromodels/pull/247) ([GallegoSav](https://github.com/GallegoSav))
 
 
 ## v2.5
@@ -536,7 +561,6 @@
 - adding additoonal search paths for gfortran because: OS X [\#14](https://github.com/threeML/astromodels/pull/14) ([grburgess](https://github.com/grburgess))
 - Fixed function3D [\#13](https://github.com/threeML/astromodels/pull/13) ([zhoouhaoo](https://github.com/zhoouhaoo))
 - Adding models [\#12](https://github.com/threeML/astromodels/pull/12) ([grburgess](https://github.com/grburgess))
-- New XSPEC uses '.' to separate versions. Added checks for this [\#6](https://github.com/threeML/astromodels/pull/6) ([grburgess](https://github.com/grburgess))
 - added OSX lib lookup [\#4](https://github.com/threeML/astromodels/pull/4) ([grburgess](https://github.com/grburgess))
 
 

--- a/astromodels/core/node_type.py
+++ b/astromodels/core/node_type.py
@@ -1,7 +1,7 @@
 import logging
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Type
+from typing import Any, Dict, Iterable, Optional, Tuple, Type
 
 from rich.tree import Tree
 
@@ -110,7 +110,7 @@ class NodeBase:
 
             raise AttributeError()
 
-    def _add_children(self, children: List[Type["NodeBase"]]) -> None:
+    def _add_children(self, children: Iterable[Type["NodeBase"]]) -> None:
 
         for child in children:
             self._add_child(child)

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -209,17 +209,7 @@ class ExtendedSource(Source, Node):
 
             brightness = self._spatial_shape(lon, lat)
 
-            # In this case the spectrum is the same everywhere
-            n_points = lat.shape[0]
-            n_energies = differential_flux.shape[0]
-
-            # subok preserves Quantity
-            cube = np.broadcast_to(
-                differential_flux, (n_points, n_energies), subok=True
-            )
-
-            result = cube * brightness.T
-
+            result = np.outer(brightness, differential_flux)
         else:
 
             result = self._spatial_shape(lon, lat, energies) * differential_flux

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -175,8 +175,9 @@ class ExtendedSource(Source, Node):
         # Get the differential flux from the spectral components
 
         spatial_int = self.spatial_shape.get_total_spatial_integral(energies)
-        differential_flux = sum(spatial_int * co.shape(energies)
-                                for co in self.components.values())
+        differential_flux = sum(
+            spatial_int * co.shape(energies) for co in self.components.values()
+        )
 
         return differential_flux
 
@@ -200,8 +201,7 @@ class ExtendedSource(Source, Node):
 
         # using sum() combines/preserves compatible units and data
         # types across components
-        differential_flux = sum(co.shape(energies)
-                                for co in self.components.values())
+        differential_flux = sum(co.shape(energies) for co in self.components.values())
 
         # Get brightness from spatial model
 
@@ -214,8 +214,9 @@ class ExtendedSource(Source, Node):
             n_energies = differential_flux.shape[0]
 
             # subok preserves Quantity
-            cube = np.broadcast_to(differential_flux,
-                                   (n_points, n_energies), subok=True)
+            cube = np.broadcast_to(
+                differential_flux, (n_points, n_energies), subok=True
+            )
 
             result = cube * brightness.T
 

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -149,7 +149,7 @@ class ExtendedSource(Source, Node):
         # Add a node called 'spectrum'
 
         spectrum_node = Node("spectrum")
-        spectrum_node._add_children(list(self._components.values()))
+        spectrum_node._add_children(self._components.values())
 
         self._add_child(spectrum_node)
 
@@ -174,27 +174,9 @@ class ExtendedSource(Source, Node):
 
         # Get the differential flux from the spectral components
 
-        results = [
-            self.spatial_shape.get_total_spatial_integral(energies)
-            * component.shape(energies)
-            for component in self.components.values()
-        ]
-
-        if isinstance(energies, u.Quantity):
-
-            # Slow version with units
-
-            # We need to sum like this (slower) because using np.sum will not preserve
-            # the units (thanks astropy.units)
-
-            differential_flux = sum(results)
-
-        else:
-
-            # Fast version without units, where x is supposed to be in the same units as
-            # currently defined in units.get_units()
-
-            differential_flux = np.sum(results, 0)
+        spatial_int = self.spatial_shape.get_total_spatial_integral(energies)
+        differential_flux = sum(spatial_int * co.shape(energies)
+                                for co in self.components.values())
 
         return differential_flux
 
@@ -216,25 +198,10 @@ class ExtendedSource(Source, Node):
 
         # Get the differential flux from the spectral components
 
-        results = [
-            component.shape(energies) for component in list(self.components.values())
-        ]
-
-        if isinstance(energies, u.Quantity):
-
-            # Slow version with units
-
-            # We need to sum like this (slower) because using np.sum will not preserve
-            # the units (thanks astropy.units)
-
-            differential_flux = sum(results)
-
-        else:
-
-            # Fast version without units, where x is supposed to be in the same units as
-            # currently defined in units.get_units()
-
-            differential_flux = np.sum(results, 0)
+        # using sum() combines/preserves compatible units and data
+        # types across components
+        differential_flux = sum(co.shape(energies)
+                                for co in self.components.values())
 
         # Get brightness from spatial model
 
@@ -246,13 +213,11 @@ class ExtendedSource(Source, Node):
             n_points = lat.shape[0]
             n_energies = differential_flux.shape[0]
 
-            # The following is a little obscure, but it is 6x faster than doing a for
-            # loop
+            # subok preserves Quantity
+            cube = np.broadcast_to(differential_flux,
+                                   (n_points, n_energies), subok=True)
 
-            cube = (
-                np.repeat(differential_flux, n_points).reshape(n_energies, n_points).T
-            )
-            result = (cube.T * brightness).T
+            result = cube * brightness.T
 
         else:
 
@@ -270,15 +235,15 @@ class ExtendedSource(Source, Node):
         :return:
         """
 
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
-            for par in list(component.shape.parameters.values()):
+            for par in component.shape.parameters.values():
 
                 if par.free:
 
                     return True
 
-        for par in list(self.spatial_shape.parameters.values()):
+        for par in self.spatial_shape.parameters.values():
 
             if par.free:
 
@@ -296,15 +261,15 @@ class ExtendedSource(Source, Node):
         """
         free_parameters = dict()
 
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
-            for par in list(component.shape.parameters.values()):
+            for par in component.shape.parameters.values():
 
                 if par.free:
 
                     free_parameters[par.path] = par
 
-        for par in list(self.spatial_shape.parameters.values()):
+        for par in self.spatial_shape.parameters.values():
 
             if par.free:
 
@@ -322,13 +287,13 @@ class ExtendedSource(Source, Node):
         """
         all_parameters = dict()
 
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
-            for par in list(component.shape.parameters.values()):
+            for par in component.shape.parameters.values():
 
                 all_parameters[par.path] = par
 
-        for par in list(self.spatial_shape.parameters.values()):
+        for par in self.spatial_shape.parameters.values():
 
             all_parameters[par.path] = par
 
@@ -351,7 +316,7 @@ class ExtendedSource(Source, Node):
         repr_dict[key]["shape"] = self._spatial_shape.to_dict(minimal=True)
         repr_dict[key]["spectrum"] = dict()
 
-        for component_name, component in list(self.components.items()):
+        for component_name, component in self.components.items():
             repr_dict[key]["spectrum"][component_name] = component.to_dict(minimal=True)
 
         return dict_to_list(repr_dict, rich_output)

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -208,11 +208,11 @@ class ExtendedSource(Source, Node):
         if self._spatial_shape.n_dim == 2:
 
             brightness = self._spatial_shape(lon, lat)
-
             result = np.outer(brightness, differential_flux)
         else:
 
-            result = self._spatial_shape(lon, lat, energies) * differential_flux
+            brightness = self._spatial_shape(lon, lat, energies)
+            result = brightness * differential_flux
 
         # Do not clip the output, otherwise it will not be possible to use ext. sources
         # with negative fluxes

--- a/astromodels/sources/extended_source.py
+++ b/astromodels/sources/extended_source.py
@@ -175,11 +175,13 @@ class ExtendedSource(Source, Node):
         # Get the differential flux from the spectral components
 
         spatial_int = self.spatial_shape.get_total_spatial_integral(energies)
-        differential_flux = sum(
-            spatial_int * co.shape(energies) for co in self.components.values()
-        )
 
-        return differential_flux
+        components = iter(self.components.values())
+        differential_flux = next(components).shape(energies)
+        for component in components:
+            differential_flux += component.shape(energies)
+
+        return spatial_int * differential_flux
 
     def __call__(self, lon, lat, energies):
         """Returns brightness of source at the given position and energy :param
@@ -199,9 +201,17 @@ class ExtendedSource(Source, Node):
 
         # Get the differential flux from the spectral components
 
-        # using sum() combines/preserves compatible units and data
-        # types across components
-        differential_flux = sum(co.shape(energies) for co in self.components.values())
+        # Create result from first component so it has the right
+        # type/unit, then add the results for any other components.
+        # (self.components() must be non-empty!)
+        #
+        # Unlike sum(), this avoids allocating a zero array
+        # and does in-place adds for any remaining components
+
+        components = iter(self.components.values())
+        differential_flux = next(components).shape(energies)
+        for component in components:
+            differential_flux += component.shape(energies)
 
         # Get brightness from spatial model
 

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -73,7 +73,19 @@ class ParticleSource(Source, Node):
         """Get the total flux of this particle source at the given energies
         (summed over the components)"""
 
-        return sum(component.shape(energies) for component in self.components.values())
+        # Create result from first component so it has the right
+        # type/unit, then add the results for any other components.
+        # (self.components() must be non-empty!)
+        #
+        # Unlike sum(), this avoids allocating a zero array
+        # and does in-place adds for any remaining components
+
+        components = iter(self.components.values())
+        flux = next(components).shape(energies)
+        for component in components:
+            flux += component.shape(energies)
+
+        return flux
 
     def _repr__base(self, rich_output=False):
         """Representation of the object.

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -73,9 +73,7 @@ class ParticleSource(Source, Node):
         """Get the total flux of this particle source at the given energies
         (summed over the components)"""
 
-        return sum(
-            component.shape(energies) for component in self.components.values()
-        )
+        return sum(component.shape(energies) for component in self.components.values())
 
     def _repr__base(self, rich_output=False):
         """Representation of the object.

--- a/astromodels/sources/particle_source.py
+++ b/astromodels/sources/particle_source.py
@@ -50,7 +50,7 @@ class ParticleSource(Source, Node):
         # Add a node called 'spectrum'
 
         spectrum_node = Node("spectrum")
-        spectrum_node._add_children(list(self._components.values()))
+        spectrum_node._add_children(self._components.values())
 
         self._add_child(spectrum_node)
 
@@ -66,18 +66,16 @@ class ParticleSource(Source, Node):
         y_unit = 1 / current_units.energy
 
         # Now set the units of the components
-        for component in list(self._components.values()):
+        for component in self._components.values():
             component.shape.set_units(x_unit, y_unit)
 
     def get_flux(self, energies):
         """Get the total flux of this particle source at the given energies
         (summed over the components)"""
 
-        results = [
-            component.shape(energies) for component in list(self.components.values())
-        ]
-
-        return numpy.sum(results, 0)
+        return sum(
+            component.shape(energies) for component in self.components.values()
+        )
 
     def _repr__base(self, rich_output=False):
         """Representation of the object.
@@ -90,12 +88,12 @@ class ParticleSource(Source, Node):
 
         repr_dict = dict()
 
-        key = "%s (particle source)" % self.name
+        key = f"{self.name} (particle source)"
 
         repr_dict[key] = dict()
         repr_dict[key]["spectrum"] = dict()
 
-        for component_name, component in list(self.components.items()):
+        for component_name, component in self.components.items():
 
             repr_dict[key]["spectrum"][component_name] = component.to_dict(minimal=True)
 

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -191,9 +191,17 @@ class PointSource(Source, Node):
 
             # No integration nor time-varying or whatever-varying
 
-            # using sum() combines/preserves compatible units and data
-            # types across components
-            results = sum(co(x, stokes) for co in self.components.values())
+            # Create result from first component so it has the right
+            # type/unit, then add the results for any other components.
+            # (self.components() must be non-empty!)
+            #
+            # Unlike sum(), this avoids allocating a zero array
+            # and does in-place adds for any remaining components
+
+            components = iter(self.components.values())
+            results = next(components)(x, stokes)
+            for component in components:
+                results += component(x, stokes)
 
         else:
 

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -201,7 +201,6 @@ class PointSource(Source, Node):
 
             integration_variable, a, b = tag
 
-
             # Suspend memoization because the memoization gets confused when
             # integrating
 
@@ -226,9 +225,7 @@ class PointSource(Source, Node):
                         return reentrant_call(x, tag=None)
 
                     # Now integrate
-                    integrals = scipy.integrate.quad_vec(
-                        integral, a, b, epsrel=1e-5
-                    )[0]
+                    integrals = scipy.integrate.quad_vec(integral, a, b, epsrel=1e-5)[0]
 
                     results = integrals / (b - a)
 

--- a/astromodels/sources/point_source.py
+++ b/astromodels/sources/point_source.py
@@ -3,7 +3,6 @@ import logging
 from typing import Dict, Optional
 
 import astropy.units as u
-import numba as nb
 import numpy as np
 import scipy.integrate
 
@@ -163,12 +162,11 @@ class PointSource(Source, Node):
         # Add a node called 'spectrum'
 
         spectrum_node = Node("spectrum")
-        spectrum_node._add_children(list(self._components.values()))
+        spectrum_node._add_children(self._components.values())
 
         self._add_child(spectrum_node)
 
-        # Now set the units
-        # Now sets the units of the parameters for the energy domain
+        # Now set the units of the parameters for the energy domain
 
         current_units = get_units()
 
@@ -180,41 +178,22 @@ class PointSource(Source, Node):
         )
 
         # Now set the units of the components
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
             component.shape.set_units(x_unit, y_unit)
 
     def __call__(self, x, tag=None, stokes=None):
 
+        is_scalar = np.isscalar(x)
+        x = np.atleast_1d(x)
+
         if tag is None:
 
             # No integration nor time-varying or whatever-varying
 
-            if isinstance(x, u.Quantity):
-
-                # Slow version with units
-
-                results = [
-                    component(x, stokes) for component in list(self.components.values())
-                ]
-                # We need to sum like this (slower) because using np.sum will not
-                # preserve the units (thanks astropy.units)
-
-                return sum(results)
-
-            else:
-
-                # Fast version without units, where x is supposed to be in the same
-                # units as currently defined in units.get_units()
-
-                results = np.array(
-                    [
-                        component(x, stokes)
-                        for component in list(self.components.values())
-                    ]
-                )
-
-                return _sum(results)
+            # using sum() combines/preserves compatible units and data
+            # types across components
+            results = sum(co(x, stokes) for co in self.components.values())
 
         else:
 
@@ -222,51 +201,41 @@ class PointSource(Source, Node):
 
             integration_variable, a, b = tag
 
-            if b is None:
 
-                # Evaluate in a, do not integrate
+            # Suspend memoization because the memoization gets confused when
+            # integrating
 
-                # Suspend memoization because the memoization gets confused when
-                # integrating
-                with use_astromodels_memoization(False):
+            with use_astromodels_memoization(False):
+
+                if b is None:
+
+                    # Evaluate at a; do not integrate
 
                     integration_variable.value = a
 
-                    res = self.__call__(x, tag=None)
+                    results = self.__call__(x, tag=None)
 
-                return res
-
-            else:
-
-                # Integrate between a and b
-                if hasattr(x, "__len__"):
-                    integrals = np.zeros(len(x))
                 else:
-                    integrals = np.zeros(1)
 
-                # TODO: implement an integration scheme avoiding the for loop
-
-                # Suspend memoization because the memoization gets confused when
-                # integrating
-                with use_astromodels_memoization(False):
+                    # Integrate between a and b
 
                     reentrant_call = self.__call__
-                    if not hasattr(x, "__len__"):
-                        x = [x]
-                    for i, e in enumerate(x):
 
-                        def integral(y):
+                    def integral(y):
+                        integration_variable.value = y
+                        return reentrant_call(x, tag=None)
 
-                            integration_variable.value = y
+                    # Now integrate
+                    integrals = scipy.integrate.quad_vec(
+                        integral, a, b, epsrel=1e-5
+                    )[0]
 
-                            return reentrant_call(e, tag=None)
+                    results = integrals / (b - a)
 
-                        # Now integrate
-                        integrals[i] = scipy.integrate.quad(
-                            integral, a, b, epsrel=1e-5
-                        )[0]
+        if is_scalar:
+            results = results.item()
 
-                return integrals / (b - a)
+        return results
 
     @property
     def has_free_parameters(self) -> bool:
@@ -275,15 +244,15 @@ class PointSource(Source, Node):
         :return:
         """
 
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
-            for par in list(component.shape.parameters.values()):
+            for par in component.shape.parameters.values():
 
                 if par.free:
 
                     return True
 
-        for par in list(self.position.parameters.values()):
+        for par in self.position.parameters.values():
 
             if par.free:
 
@@ -301,15 +270,15 @@ class PointSource(Source, Node):
         """
         free_parameters = dict()
 
-        for component in list(self._components.values()):
+        for component in self._components.values():
 
-            for par in list(component.shape.parameters.values()):
+            for par in component.shape.parameters.values():
 
                 if par.free:
 
                     free_parameters[par.path] = par
 
-        for par in list(self.position.parameters.values()):
+        for par in self.position.parameters.values():
 
             if par.free:
 
@@ -356,13 +325,8 @@ class PointSource(Source, Node):
         repr_dict[key]["position"] = self._sky_position.to_dict(minimal=True)
         repr_dict[key]["spectrum"] = dict()
 
-        for component_name, component in list(self.components.items()):
+        for component_name, component in self.components.items():
 
             repr_dict[key]["spectrum"][component_name] = component.to_dict(minimal=True)
 
         return dict_to_list(repr_dict, rich_output)
-
-
-@nb.njit(fastmath=True)
-def _sum(x):
-    return np.sum(x, axis=0)

--- a/astromodels/sources/source.py
+++ b/astromodels/sources/source.py
@@ -3,7 +3,7 @@ import logging
 __author__ = "giacomov"
 
 from enum import Enum, unique
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable
 
 from astromodels.core.parameter import Parameter
 
@@ -26,7 +26,7 @@ class UnknownSourceType(Exception):
 
 class Source(object):
     def __init__(
-        self, list_of_components: List[Any], src_type: str, spatial_shape=None
+        self, list_of_components: Iterable[Any], src_type: str, spatial_shape=None
     ):
 
         # Make the dictionary of components

--- a/astromodels/tests/test_model.py
+++ b/astromodels/tests/test_model.py
@@ -1011,7 +1011,7 @@ def test_time_domain_integration():
         0, energies, tag=(time, 0, 10)
     )  # type: np.ndarray
 
-    assert np.all(results == 1.0)
+    assert np.allclose(results, 1.0, rtol=1e-15)
 
     # Now test the linking of the normalization, first with a constant then with a line
     # with a certain angular coefficient


### PR DESCRIPTION
This patch cleans up the classes in the sources subdirectory.  Changes include

* don't use Numba for the sum in point_source.py -- it was just wrapping a Numpy vectorized sum call, so confers no performance advantage
* simplify _call_ / get_flux methods to sum over an iterator,  rather than trying to convert to a list or array first.  Rather than call Python sum(), which instantiates a 0 value and adds to it, we grab the first result from the iterator directly, then do in-place adds of the remaining iterator values.  This pattern has proved between 3 and 10x faster for our use cases vs using sum(), should never be slower, and should be safe for both bare arrays and Quantity arrays with compatible units.
* for point_source integration, use SciPy's integrate.quad_vec() to do integrals for all values of x in one call, rather than separately for each value
* don't convert iterators to lists unnecessarily where the iterable can be used directly, and update type signatures to match

One point_source integration test was updated to allow the result to differ by a very small amount (1e-15) from the analytically expected 1 as a result of using quad_vec().

It is my contention that the rewritten code is not slower than the original, more complex version.  But I would appreciate suggestions on appropriate test cases to convincingly verify this hypothesis.

One data point so far: while testing cosipy with the updated ExtendedSource class using a model (Gassian_on_sphere) with a 2D spatial_shape with len(brightness) = 10, we found that __call__ runs at about the same speed for 1000 spatial points and 3x faster for 10000 points.