### PR TITLE
BLD: add explicit lower bounds to build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-    requires = ["setuptools","versioneer[toml]","numpy"]
+    requires = [
+		"setuptools>=77.0.1",
+		"versioneer[toml]>=0.29",
+		"numpy>=1.25.0",
+	]
     build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
`setuptools>=77.0.1` is needed for `project.license-files`, `numpy>=1.25.0` is a safe default as the first version that's able to compile backward compatible binaries. `versioneer>=0.29` is arbitrary, as the current latest version, and the only version I can bet actually works without checking. It's also old enough (3 y.o.) that it shouldn't be controversial.