### PR TITLE
WHL: publish pure Python wheels to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 jobs:
 
     publish-pypi:
-        name: Publish to PyPi
+        name: Publish to PyPI
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
         runs-on: ubuntu-latest
         permissions:
@@ -26,43 +26,34 @@ jobs:
         steps:
             - name: Checkout source
               uses: actions/checkout@v6
-            - name: Set up Python 3.11
-              uses: actions/setup-python@v5
+            - uses: astral-sh/setup-uv@v10
               with:
-                  python-version: 3.11
-            - name: Build package
+                  enable-cache: false
+            - name: Build artifacts (sdist + pure Python wheel)
               run: |
-                  pip install wheel setuptools packaging -U
-                  python setup.py sdist
+                  uv build
+                  uvx twine check dist/*
             - name: Publish
               uses: pypa/gh-action-pypi-publish@release/v1
               with:
                   skip-existing: true
 
     test-publish-pypi:
-      name: Build & verify PyPi
+      name: Build & verify PyPI
       runs-on: ubuntu-latest
 
       steps:
           - uses: actions/checkout@v6
-          - uses: actions/setup-python@v5
+          - uses: astral-sh/setup-uv@v10
             with:
-                python-version: 3.11
-
-          - name: Install twine
+                enable-cache: false
+          - name: Build artifacts (sdist + pure Python wheel)
             run: |
-                python -m pip install twine
-          - name: Build package
-            run: |
-              pip install wheel setuptools -U
-              python setup.py sdist
-
+                uv build
+                uvx twine check dist/*
           - name: List result
             run: |
                 ls -lh dist
-          - name: Check long_description
-            run: |
-                python -m twine check dist/*
 
     build-conda:
       name: Build for Conda


### PR DESCRIPTION
I noticed that only source distributions were available on PyPI, even though the package *can* be built as pure-Python (excluding xspec support). Publishing pure-Python wheels would help PyPI users as it would avoid potential incompatibilities at build-time (particularily for old versions, as build-time dependencies might drift with time), as well as removing a potential attack vector from the build-backend (as installing from source requires running arbitrary code that lives mostly outside this repo).