### PR TITLE
DEP: update and define missing minimal requirements on runtime Python dependencies with compiled modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,15 @@
     requires-python = ">=3.11.0"
     dependencies = [
 	"numpy>=1.26",
-	"PyYAML>=5.1",
-	"scipy>=0.14",
+	"PyYAML>=6.0",
+	"scipy>=1.9.2",
 	"astropy>=7.2",
 	"dill",
-	"numba",
+	"numba>=0.57.0",
 	"llvmlite<0.46; platform_system == 'Darwin' and platform_machine == 'x86_64'",
-	"h5py",
-	"pandas",
-	"tables",
+	"h5py>=3.8.0",
+	"pandas>=1.5.0",
+	"tables>=3.8.0",
 	"omegaconf",
 	"rich",
 	"versioneer"


### PR DESCRIPTION
defining explicit lower bounds helps to guide dependency resolvers through constrained setups. Here I'm just setting very conservative bounds on packages that have compiled modules to the oldest versions with Python 3.11 support.