### PR TITLE
DEP: drop platform-specific constraint on llvmlite as an indirect runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@
 	"astropy>=7.2",
 	"dill",
 	"numba",
-	"llvmlite<0.46; platform_system == 'Darwin' and platform_machine == 'x86_64'",
 	"h5py",
 	"pandas",
 	"tables",


### PR DESCRIPTION
My guess is that this was added merely as a *constraint* rather than an actual direct dependency; it's really used by numba but not directly from this package. Upper bounds infamously tend to degenerate into tripwire for dependency resolvers so let's try to loosen this one and see if it's still having an effect.