### PR TITLE
TST: add CPython 3.14 to test matrix

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -36,7 +36,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                python-version: ["3.11", "3.12", "3.13"]
+                python-version:
+                  - "3.11"
+                  - "3.12"
+                  - "3.13"
+                  - "3.14"
                 os: ["ubuntu-latest", "macos-latest", "macos-15-intel","ubuntu-24.04-arm"]
         runs-on: ${{ matrix.os }}
         steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@
 	"Programming Language :: Python :: 3.11",
 	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: 3.13",
+	"Programming Language :: Python :: 3.14",
 	"Environment :: Console",
     ]
 


### PR DESCRIPTION
Supposedly nothing should be blocking this almost a year after 3.14.0 was finalized and released.