### PR TITLE
RFC: autofix `unnecessary-builtin-import` (`UP029`)

### DIFF
--- a/astromodels/core/model.py
+++ b/astromodels/core/model.py
@@ -1,6 +1,5 @@
 import logging
 
-from builtins import zip
 
 __author__ = "giacomov"
 

--- a/astromodels/core/model_parser.py
+++ b/astromodels/core/model_parser.py
@@ -1,6 +1,5 @@
 import logging
 
-from builtins import object, str
 
 __author__ = "giacomov"
 

--- a/astromodels/core/parameter_transformation.py
+++ b/astromodels/core/parameter_transformation.py
@@ -1,5 +1,4 @@
 import math
-from builtins import object
 
 import numba as nb
 import numpy as np

--- a/astromodels/core/thread_safe_unit_format.py
+++ b/astromodels/core/thread_safe_unit_format.py
@@ -5,7 +5,6 @@
 # ply.yacc and is thread safe
 
 import re
-from builtins import map, str, zip
 from functools import reduce
 
 import astropy.units as u

--- a/astromodels/core/units.py
+++ b/astromodels/core/units.py
@@ -1,4 +1,3 @@
-from builtins import object
 
 __author__ = "giacomov"
 

--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -9,7 +9,6 @@ import re
 import sys
 import textwrap
 import uuid
-from builtins import chr, map, str
 from operator import attrgetter
 from typing import Dict, List, Optional, Tuple
 

--- a/astromodels/functions/spatial_model.py
+++ b/astromodels/functions/spatial_model.py
@@ -5,7 +5,6 @@ import gc
 import hashlib
 import os
 import re
-from builtins import range, str
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path

--- a/astromodels/tests/test_memoizer.py
+++ b/astromodels/tests/test_memoizer.py
@@ -1,4 +1,3 @@
-from builtins import zip
 
 import numpy as np
 

--- a/astromodels/tests/test_model.py
+++ b/astromodels/tests/test_model.py
@@ -1,5 +1,4 @@
 import os
-from builtins import object, range
 
 import pytest
 

--- a/astromodels/tests/test_parameter.py
+++ b/astromodels/tests/test_parameter.py
@@ -1,4 +1,3 @@
-from builtins import object
 
 import astropy.units as u
 import pytest

--- a/astromodels/tests/test_tree.py
+++ b/astromodels/tests/test_tree.py
@@ -1,5 +1,4 @@
 import gc
-from builtins import range
 
 import astropy.units as u
 import pytest

--- a/astromodels/utils/pretty_list.py
+++ b/astromodels/utils/pretty_list.py
@@ -1,4 +1,3 @@
-from builtins import str
 
 __author__ = "giacomov"
 


### PR DESCRIPTION
autofixed with `ruff check  astromodels --select UP029 --fix --unsafe-fixes`
(the fix is marked "unsafe" because it drops comments, which doesn't apply here)