### PR TITLE
CLN: drop private Python 2 compatibility helper function

### DIFF
--- a/astromodels/functions/function.py
+++ b/astromodels/functions/function.py
@@ -93,17 +93,6 @@ class UnknownParameter(ValueError):
 NO_LATEX_FORMULA = "(no latex formula available)"
 
 
-# A function to find the calling sequence of a function, compatible
-# with both python2 and 3
-def _py2to3_getargspec(function):
-    if sys.version_info[0] < 3:
-        argspec = inspect.getargspec(function)
-
-    else:  # PY3
-        argspec = inspect.getfullargspec(function)
-
-    return argspec
-
 
 # This dictionary will contain the known function by name, so that the model_parser can
 # instance them by looking into this dictionary. It will be filled by the FunctionMeta
@@ -494,12 +483,12 @@ class FunctionMeta(type):
         # If the function has been memoized, it will have a "input_object" member
 
         try:
-            calling_sequence = _py2to3_getargspec(function.input_object).args
+            calling_sequence = inspect.getfullargspec(function.input_object).args
 
         except AttributeError:
             # This might happen if the function is without memoization
 
-            calling_sequence = _py2to3_getargspec(function).args
+            calling_sequence = inspect.getfullargspec(function).args
 
         if not calling_sequence[0] == "self":
             log.error(


### PR DESCRIPTION
discovered with `ruff check astromodels --select UP036`, and fixed manually.