### PR TITLE
Add a general Prior class + fix numerical instabilities Log_parabola + use warnings instead of logger 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 
 ## v2.6
-### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-06-26)
+### [v2.6.0](https://github.com/threeML/astromodels/tree/v2.6.0) (2026-07-31)
 
 [Full Changelog](https://github.com/threeML/astromodels/compare/v2.5.1...v2.6.0)
+
+**Implemented enhancements:**
+
+- Use builtin dicts instead of OrderedDicts [\#262](https://github.com/threeML/astromodels/pull/262) ([PreisTo](https://github.com/PreisTo))
 
 **Closed issues:**
 
@@ -13,6 +17,27 @@
 - ThreadSafe error with latest astromodels dev [\#243](https://github.com/threeML/astromodels/issues/243)
 - SpatialTemplate\_2D, ExtendedSource and default units [\#238](https://github.com/threeML/astromodels/issues/238)
 - Error Importing Astromodels with python 3.11.3 [\#201](https://github.com/threeML/astromodels/issues/201)
+
+**Merged pull requests:**
+
+- Fix custom startup\_warnings setup in user configs [\#282](https://github.com/threeML/astromodels/pull/282) ([PreisTo](https://github.com/PreisTo))
+- Dev [\#279](https://github.com/threeML/astromodels/pull/279) ([ndilalla](https://github.com/ndilalla))
+- Fix requiring two numpy versions conda [\#278](https://github.com/threeML/astromodels/pull/278) ([PreisTo](https://github.com/PreisTo))
+- Add Polarizaton Transformation [\#275](https://github.com/threeML/astromodels/pull/275) ([PreisTo](https://github.com/PreisTo))
+- Update build dependencies [\#274](https://github.com/threeML/astromodels/pull/274) ([PreisTo](https://github.com/PreisTo))
+- Fix failing conda CIs + move from boa to rattler-build [\#273](https://github.com/threeML/astromodels/pull/273) ([PreisTo](https://github.com/PreisTo))
+- Multicore setup for pytest [\#268](https://github.com/threeML/astromodels/pull/268) ([PreisTo](https://github.com/PreisTo))
+- Implement template-fitting class [\#267](https://github.com/threeML/astromodels/pull/267) ([torresramiro350](https://github.com/torresramiro350))
+- Support calling PointSource without \_\_len\_\_ [\#266](https://github.com/threeML/astromodels/pull/266) ([PreisTo](https://github.com/PreisTo))
+- Stokes Polarization from floats [\#265](https://github.com/threeML/astromodels/pull/265) ([PreisTo](https://github.com/PreisTo))
+- Suggestion for codecov settings [\#263](https://github.com/threeML/astromodels/pull/263) ([PreisTo](https://github.com/PreisTo))
+- Remove unused dependencies + fix conda withouth xspec [\#261](https://github.com/threeML/astromodels/pull/261) ([PreisTo](https://github.com/PreisTo))
+- Use logging.getLogger\(\_\_name\_\_\) instead of setup\_logger [\#260](https://github.com/threeML/astromodels/pull/260) ([israelmcmc](https://github.com/israelmcmc))
+- Add integrate\(\) function [\#257](https://github.com/threeML/astromodels/pull/257) ([PreisTo](https://github.com/PreisTo))
+- New docs changes [\#255](https://github.com/threeML/astromodels/pull/255) ([ndilalla](https://github.com/ndilalla))
+- Build mutliple versions for conda using variants [\#252](https://github.com/threeML/astromodels/pull/252) ([PreisTo](https://github.com/PreisTo))
+- Unpolarized class as default polarization [\#249](https://github.com/threeML/astromodels/pull/249) ([PreisTo](https://github.com/PreisTo))
+- Validate CAR coordinates and adjust area calculation [\#247](https://github.com/threeML/astromodels/pull/247) ([GallegoSav](https://github.com/GallegoSav))
 
 
 ## v2.5
@@ -536,7 +561,6 @@
 - adding additoonal search paths for gfortran because: OS X [\#14](https://github.com/threeML/astromodels/pull/14) ([grburgess](https://github.com/grburgess))
 - Fixed function3D [\#13](https://github.com/threeML/astromodels/pull/13) ([zhoouhaoo](https://github.com/zhoouhaoo))
 - Adding models [\#12](https://github.com/threeML/astromodels/pull/12) ([grburgess](https://github.com/grburgess))
-- New XSPEC uses '.' to separate versions. Added checks for this [\#6](https://github.com/threeML/astromodels/pull/6) ([grburgess](https://github.com/grburgess))
 - added OSX lib lookup [\#4](https://github.com/threeML/astromodels/pull/4) ([grburgess](https://github.com/grburgess))
 
 

--- a/astromodels/core/parameter.py
+++ b/astromodels/core/parameter.py
@@ -1,13 +1,12 @@
 import logging
+import warnings
 
 __author__ = "giacomov"
 
 __doc__ = """"""
 
-import collections
 import contextlib
 import copy
-import warnings
 from typing import Any, Dict, Optional, Tuple
 
 import astropy.units as u
@@ -714,9 +713,10 @@ class ParameterBase(Node):
                     # set it by default to for the user
                     min_value = 1e-99
 
-                    log.warning(
+                    warnings.warn(
                         f"We have set the min_value of {self.path} to 1e-99 because"
-                        " there was a postive transform"
+                        " there was a postive transform",
+                        UserWarning,
                     )
 
         # Store the minimum as a pure float
@@ -731,10 +731,11 @@ class ParameterBase(Node):
             and self.value < self._external_min_value
         ):
 
-            log.warning(
+            warnings.warn(
                 "The current value of the parameter %s (%s) "
                 "was below the new minimum %s."
-                % (self.name, self.value, self._external_min_value)
+                % (self.name, self.value, self._external_min_value),
+                RuntimeWarning,
             )
 
             self.value = self._external_min_value
@@ -798,7 +799,6 @@ class ParameterBase(Node):
     @accept_quantity(float, allow_none=True)
     def _set_max_value(self, max_value) -> None:
         """Sets current maximum allowed value."""
-
         self._external_max_value = max_value
 
         # Check that the current value of the parameter is still within the boundaries.
@@ -808,11 +808,11 @@ class ParameterBase(Node):
             self._external_max_value is not None
             and self.value > self._external_max_value
         ):
-
-            log.warning(
+            warnings.warn(
                 "The current value of the parameter %s (%s) "
                 "was above the new maximum %s."
-                % (self.name, self.value, self._external_max_value)
+                % (self.name, self.value, self._external_max_value),
+                RuntimeWarning,
             )
             self.value = self._external_max_value
 

--- a/astromodels/functions/functions_1D/functions.py
+++ b/astromodels/functions/functions_1D/functions.py
@@ -663,6 +663,15 @@ class Log_parabola(Function1D, metaclass=FunctionMeta):
             desc : curvature (positive is concave, negative is convex)
             initial value : 1.0
 
+    properties :
+
+        clip_value :
+            desc : Value at which the log value of the evaluation will be clipped
+                    e.g. anything larger than exp(700) or smaller than exp(-700) will
+                    return 0
+            initial value : 700
+
+
     """
 
     def _set_units(self, x_unit, y_unit):
@@ -679,26 +688,21 @@ class Log_parabola(Function1D, metaclass=FunctionMeta):
         self.beta.unit = astropy_units.dimensionless_unscaled
 
     def evaluate(self, x, K, piv, alpha, beta):
-
-        # print("Receiving %s" % ([K, piv, alpha, beta]))
-
-        xx = np.divide(x, piv)
-
-        try:
-
-            return K * xx ** (alpha - beta * np.log(xx))
-
-        except ValueError:
-
-            # The current version of astropy (1.1.x) has a bug for which quantities that
-            # have become dimensionless because of a division (like xx here) are not
-            # recognized as such by the power operator, which throws an exception:
-            # ValueError: Quantities and Units may only be raised to a scalar power
-            # This is a quick fix, waiting for astropy 1.2 which will fix this
-
-            xx = xx.to("")
-
-            return K * xx ** (alpha - beta * np.log(xx))
+        if isinstance(x, u.Quantity):
+            x = x.to(piv.unit).value
+            unit = K.unit
+            K = K.value
+            piv = piv.value
+            alpha = alpha.value
+            beta = beta.value
+        else:
+            unit = 1.0
+        log_xx = np.log(x / piv)
+        log_result = np.log(K) + (alpha - beta * log_xx) * log_xx
+        log_result = np.clip(
+            log_result, -float(self.clip_value.value), float(self.clip_value.value)
+        )
+        return np.exp(log_result) * unit
 
     @property
     def peak_energy(self):

--- a/astromodels/functions/priors.py
+++ b/astromodels/functions/priors.py
@@ -27,6 +27,12 @@ class Prior(Function1D):
     def dim(self):
         return 1
 
+    def _get_support(self):
+        if hasattr(self, "lower_bound") and hasattr(self, "upper_bound"):
+            return self.lower_bound.value, self.upper_bound.value
+        else:
+            return -np.inf, np.inf
+
     @property
     def scipy_dist(self):
         """Return a frozen scipy rv_continuous-like object."""
@@ -37,9 +43,20 @@ class Prior(Function1D):
                 def _pdf(self_inner, x):
                     return parent._pdf_scipy(x)
 
-            self._scipy_dist = _ScipyWrapper(
-                a=self.lower_bound.value, b=self.upper_bound.value, name=self.name
-            )
+                def _logpdf(self_inner, x):
+                    return parent._logpdf_scipy(x)
+
+                def _get_support(self_inner, *args, **kwargs):
+                    return parent._get_support(*args, **kwargs)
+
+            # here we initialize the scipy wrapping class and assign it
+            if hasattr(self, "lower_bound") and hasattr(self, "upper_bound"):
+                self._scipy_dist = _ScipyWrapper(
+                    a=self.lower_bound.value, b=self.upper_bound.value, name=self.name
+                )
+            else:
+                self._scipy_dist = _ScipyWrapper(name=self.name)
+
         return self._scipy_dist
 
 

--- a/astromodels/functions/priors.py
+++ b/astromodels/functions/priors.py
@@ -49,13 +49,10 @@ class Prior(Function1D):
                 def _get_support(self_inner, *args, **kwargs):
                     return parent._get_support(*args, **kwargs)
 
-            # here we initialize the scipy wrapping class and assign it
-            if hasattr(self, "lower_bound") and hasattr(self, "upper_bound"):
-                self._scipy_dist = _ScipyWrapper(
-                    a=self.lower_bound.value, b=self.upper_bound.value, name=self.name
-                )
-            else:
-                self._scipy_dist = _ScipyWrapper(name=self.name)
+                def rvs(self_inner, size=1):
+                    return parent.rvs(size)
+
+            self._scipy_dist = _ScipyWrapper(name=self.name)
 
         return self._scipy_dist
 

--- a/astromodels/functions/priors.py
+++ b/astromodels/functions/priors.py
@@ -620,13 +620,15 @@ class Uniform_prior(Prior, metaclass=FunctionMeta):
 
     def evaluate(self, x, lower_bound, upper_bound, value):
         # The value * 0 is to keep the units right
+        if hasattr(x, "shape"):
+            result = np.zeros(x.shape) * value * 0
 
-        result = np.zeros(x.shape) * value * 0
+            idx = (x >= lower_bound) & (x <= upper_bound)
+            result[idx] = value
 
-        idx = (x >= lower_bound) & (x <= upper_bound)
-        result[idx] = value
-
-        return result
+            return result
+        else:
+            return value if (x >= lower_bound) & (x <= upper_bound) else 0
 
     def from_unit_cube(self, x):
         """Used by multinest.

--- a/astromodels/functions/priors.py
+++ b/astromodels/functions/priors.py
@@ -13,7 +13,37 @@ rad2deg = 180.0 / np.pi
 # noinspection PyPep8Naming
 
 
-class Gaussian(Function1D, metaclass=FunctionMeta):
+class Prior(Function1D):
+
+    def _pdf_scipy(self, x):
+        return self.evaluate(x, *[p.value for p in self.parameters.values()])
+
+    def _logpdf_scipy(self, x):
+        return np.log(self._pdf_scipy(x))
+
+    def rvs(self, size=1):
+        return self.from_unit_cube(np.random.rand(size))
+
+    def dim(self):
+        return 1
+
+    @property
+    def scipy_dist(self):
+        """Return a frozen scipy rv_continuous-like object."""
+        if not hasattr(self, "_scipy_dist"):
+            parent = self
+
+            class _ScipyWrapper(stats.rv_continuous):
+                def _pdf(self_inner, x):
+                    return parent._pdf_scipy(x)
+
+            self._scipy_dist = _ScipyWrapper(
+                a=self.lower_bound.value, b=self.upper_bound.value, name=self.name
+            )
+        return self._scipy_dist
+
+
+class Gaussian(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -98,7 +128,7 @@ class Gaussian(Function1D, metaclass=FunctionMeta):
         return res
 
 
-class Truncated_gaussian(Function1D, metaclass=FunctionMeta):
+class Truncated_gaussian(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -243,7 +273,7 @@ class Truncated_gaussian(Function1D, metaclass=FunctionMeta):
         return np.clip(out, lower_bound, upper_bound)
 
 
-class Cauchy(Function1D, metaclass=FunctionMeta):
+class Cauchy(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -319,7 +349,7 @@ class Cauchy(Function1D, metaclass=FunctionMeta):
         return res
 
 
-class Cosine_Prior(Function1D, metaclass=FunctionMeta):
+class Cosine_Prior(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -424,7 +454,7 @@ class Cosine_Prior(Function1D, metaclass=FunctionMeta):
         return dec
 
 
-class Log_normal(Function1D, metaclass=FunctionMeta):
+class Log_normal(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -533,7 +563,7 @@ class Log_normal(Function1D, metaclass=FunctionMeta):
         return np.exp(res)
 
 
-class Uniform_prior(Function1D, metaclass=FunctionMeta):
+class Uniform_prior(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -618,7 +648,7 @@ class Uniform_prior(Function1D, metaclass=FunctionMeta):
         return par
 
 
-class Log_uniform_prior(Function1D, metaclass=FunctionMeta):
+class Log_uniform_prior(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -703,7 +733,7 @@ class Log_uniform_prior(Function1D, metaclass=FunctionMeta):
         return par
 
 
-class Beta(Function1D, metaclass=FunctionMeta):
+class Beta(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -756,7 +786,7 @@ class Beta(Function1D, metaclass=FunctionMeta):
         return stats.beta.ppf(x, a, b)
 
 
-class Gamma(Function1D, metaclass=FunctionMeta):
+class Gamma(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -810,7 +840,7 @@ class Gamma(Function1D, metaclass=FunctionMeta):
         return stats.gamma.ppf(x, alpha, scale=1.0 / beta)
 
 
-class Exponential(Function1D, metaclass=FunctionMeta):
+class Exponential(Prior, metaclass=FunctionMeta):
     r"""
     description :
 
@@ -853,7 +883,7 @@ class Exponential(Function1D, metaclass=FunctionMeta):
         return stats.expon.ppf(x, scale=1.0 / self.alpha.value)
 
 
-class Powerlaw_Prior(Function1D, metaclass=FunctionMeta):
+class Powerlaw_Prior(Prior, metaclass=FunctionMeta):
     r"""
     description :
 

--- a/astromodels/tests/test_priors.py
+++ b/astromodels/tests/test_priors.py
@@ -1,0 +1,19 @@
+from astromodels.functions.priors import Uniform_prior, Log_uniform_prior, Gaussian
+import numpy as np
+
+
+def test_bounded_prior():
+    logp = Log_uniform_prior(lower_bound=0.1, upper_bound=1)
+    assert logp(0.2) == logp.scipy_dist.pdf(0.2)
+
+    bounds = logp.scipy_dist.support()
+    assert bounds[0] == logp.lower_bound.value
+    assert bounds[1] == logp.upper_bound.value
+
+    uni = Uniform_prior(lower_bound=-1, upper_bound=1)
+    rvs = uni.scipy_dist.rvs(size=100000)
+    assert np.isclose(rvs.mean(), 0.0, atol=rvs.std() * 2)
+
+    bounds = uni.scipy_dist.support()
+    assert bounds[0] == uni.lower_bound.value
+    assert bounds[1] == uni.upper_bound.value


### PR DESCRIPTION
This adds a general Prior class inheriting `Function1D` that has a `scipy_dist` property that provides a wrapper to a scipy continuous distribution, useful for some samplers that depend on that.


Plus bonus change because I messed up some branches: clip unreasonable high values for Log_parabola:
- value is set as a property and customizable
- default is exp(+/-700) 

Use the warnings package to be able to catch those warnings e.g. in 3ML when getting a model via a Catalog 

<!-- readthedocs-preview astromodels start -->
----
📚 Documentation preview 📚: https://astromodels--300.org.readthedocs.build/en/300/

<!-- readthedocs-preview astromodels end -->